### PR TITLE
Skyns

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -24,8 +24,8 @@ limit_conn_zone $binary_remote_addr zone=downloads_by_ip:10m;
 limit_req_status 429;
 limit_conn_status 429;
 
-# since we are proxying request to nginx from caddy, access logs will contain caddy's ip address 
-# as the request address so we need to use real_ip_header module to use ip address from 
+# since we are proxying request to nginx from caddy, access logs will contain caddy's ip address
+# as the request address so we need to use real_ip_header module to use ip address from
 # X-Forwarded-For header as a real ip address of the request
 set_real_ip_from  10.0.0.0/8;
 set_real_ip_from  127.0.0.1/32;
@@ -113,11 +113,11 @@ server {
 			local file_exists = io.open("/data/nginx/skynet/prevstats.lua")
 			if file_exists then
 				file_exists.close()
-				
+
 				-- because response data is chunked, we need to concat ngx.arg[1] until
 				-- last chunk is received (when ngx.arg[2] is set to true)
 				ngx.var.response_body = ngx.var.response_body .. ngx.arg[1]
-				
+
 				if ngx.arg[2] then
 					local json = require('cjson')
 					local prevstats = require('/data/nginx/skynet/prevstats')
@@ -139,6 +139,69 @@ server {
 		proxy_pass http://siad/skynet/stats;
 	}
 
+	location /skyns {
+		include /etc/nginx/conf.d/include/proxy-buffer;
+
+		# variable definititions - we need to define a variable to be able to access it in lua by ngx.var.something
+		set $skylink ''; # placeholder for the raw 46 bit skylink
+		set $rest ''; # placeholder for the rest of the url that gets appended to skylink (path and args)
+
+		# resolve handshake domain by requesting to /hnsres endpoint and assign correct values to $skylink and $rest
+		access_by_lua_block {
+			local json = require('cjson')
+
+			-- match the request_uri and extract the publickey and datakey
+			-- example: /skyns/<publickey>/<datakey>
+			local publickey, datakey = string.match(ngx.var.request_uri, "/skyns/([^/?]+)/(.*)/?")
+
+			-- make a get request to /skynet/registry endpoint with the credentials from text record
+			local registry_res = ngx.location.capture("/skynet/registry?publickey=" .. publickey .. "&datakey=" .. datakey)
+
+			-- we want to fail with a generic 404 when /skynet/registry returns anything but 200 OK
+			if registry_res.status ~= ngx.HTTP_OK then
+				ngx.exit(ngx.HTTP_NOT_FOUND)
+			end
+
+			-- since /skynet/registry endpoint response is a json, we need to decode it before we access it
+			local registry_json = json.decode(registry_res.body)
+			-- response will contain a hex encoded skylink, we need to decode it
+			local data = (registry_json.data:gsub('..', function (cc)
+				return string.char(tonumber(cc, 16))
+			end))
+
+			skylink = data
+
+			-- fail with a generic 404 if skylink has not been extracted from a valid response for some reason
+			if not skylink then
+				ngx.exit(ngx.HTTP_NOT_FOUND)
+			end
+
+			ngx.var.skylink = skylink
+			ngx.var.rest = request_uri_rest
+		}
+
+		# overwrite the Cache-Control header to only cache for 60s in case the domain gets updated
+		more_set_headers 'Cache-Control: public, max-age=60';
+
+		# we proxy to another nginx location rather than directly to siad because we don't want to deal with caching here
+		proxy_pass http://127.0.0.1/$skylink$rest;
+
+		# in case siad returns location header, we need to replace the skylink with the domain name
+		header_filter_by_lua_block {
+			if ngx.header.location then
+				-- match hns domain from the request_uri
+				local hns_domain_name = string.match(ngx.var.request_uri, "/hns/([^/?]+)")
+
+				-- match location redirect part after the skylink
+				local location_rest = string.match(ngx.header.location, "[^/?]+(.*)");
+
+				-- because siad will set the location header to ie. XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg/index.html
+				-- we need to replace the skylink with the domain_name so we are not redirected to skylink
+				ngx.header.location = hns_domain_name .. location_rest
+			end
+		}
+	}
+
 	location /health-check {
 		include /etc/nginx/conf.d/include/cors;
 
@@ -153,11 +216,11 @@ server {
 		# variable definititions - we need to define a variable to be able to access it in lua by ngx.var.something
 		set $skylink ''; # placeholder for the raw 46 bit skylink
 		set $rest ''; # placeholder for the rest of the url that gets appended to skylink (path and args)
-		
+
 		# resolve handshake domain by requesting to /hnsres endpoint and assign correct values to $skylink and $rest
 		access_by_lua_block {
 			local json = require('cjson')
-			
+
 			-- match the request_uri and extract the hns domain and anything that is passed in the uri after it
 			-- example: /hns/something/foo/bar?baz=1 matches:
 			-- > hns_domain_name: something
@@ -221,7 +284,7 @@ server {
 
 		# overwrite the Cache-Control header to only cache for 60s in case the domain gets updated
 		more_set_headers 'Cache-Control: public, max-age=60';
-		
+
 		# we proxy to another nginx location rather than directly to siad because we don't want to deal with caching here
 		proxy_pass http://127.0.0.1/$skylink$rest;
 

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -152,7 +152,7 @@ server {
 
 			-- match the request_uri and extract the publickey and datakey
 			-- example: /skyns/<publickey>/<datakey>
-			local publickey, datakey = string.match(ngx.var.request_uri, "/skyns/([^/?]+)/(.*)/?")
+			local publickey, datakey, request_uri_rest = string.match(ngx.var.request_uri, "/skyns/([^/?]+)/([^/?]+)(.*)")
 
 			-- make a get request to /skynet/registry endpoint with the credentials from text record
 			local registry_res = ngx.location.capture("/skynet/registry?publickey=" .. publickey .. "&datakey=" .. datakey)
@@ -185,21 +185,6 @@ server {
 
 		# we proxy to another nginx location rather than directly to siad because we don't want to deal with caching here
 		proxy_pass http://127.0.0.1/$skylink$rest;
-
-		# in case siad returns location header, we need to replace the skylink with the domain name
-		header_filter_by_lua_block {
-			if ngx.header.location then
-				-- match hns domain from the request_uri
-				local hns_domain_name = string.match(ngx.var.request_uri, "/hns/([^/?]+)")
-
-				-- match location redirect part after the skylink
-				local location_rest = string.match(ngx.header.location, "[^/?]+(.*)");
-
-				-- because siad will set the location header to ie. XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg/index.html
-				-- we need to replace the skylink with the domain_name so we are not redirected to skylink
-				ngx.header.location = hns_domain_name .. location_rest
-			end
-		}
 	}
 
 	location /health-check {


### PR DESCRIPTION
**Proposal**: 
Add support to `/skyns/<publicKey>/<dataKey>/*`

**Why?**
* I was looking for a way to validate my `skyns` link before adding it to a HNS domain. This endpoint could facilitate a lot
* In my server (not a portal) I have a subdomain with `proxy_pass https://<key>.siasky.net;`. It would be handy if I could set the `skyns` in the URL

The majority of this code was copied from the `/hns` section. Maybe it worth a refator. 
The goal of this PR is to demonstrate the proposal, not necessarily to be merged.