### PR TITLE
default Caddyfile configuration to our production servers

### DIFF
--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -10,12 +10,17 @@
     reverse_proxy nginx:80
 }
 
-# Make sure you have DOMAIN_NAME specified in .env file ie. siasky.net, you need it to fetch correct certificates.
-# DOMAIN_NAME_ALIAS is optional, in case you run multiple servers under the same domain like we do for siasky.net
-# then you might want to use it for something server specific that would let you connect to this specific server
-# and disregard load balancer, ie. germany.siasky.net
+# Make sure you have SSL_CERTIFICATE_STRING specified in .env file because you need it to fetch correct certificates.
+# It needs to have at least 3 parts, the absolute part (ie. example.com), the wildcard part (ie. *.example.com) and
+# the hns wildcard part (ie. *.hns.example.com). The resulting string should look like:
+# example.com, *.example.com, *.hns.example.com
+# In addition, if you are running multiple servers for the single portal like we do on siasky.net, you might want to
+# add an aliased string that is going to help you access and distinguish between servers, the result would look like:
+# example.com, *.example.com, *.hns.example.com, *.germany.example.com, *.hns.germany.example.com
+# Note that you don't need to specify the absolute part for the alias since it's already covered in the wildcard part 
+# of the original certificate string (*.example.com).
 
-{$DOMAIN_NAME}, *.{$DOMAIN_NAME}, *.hns.{$DOMAIN_NAME}, {$DOMAIN_NAME_ALIAS}, *.{$DOMAIN_NAME_ALIAS}, *.hns.{$DOMAIN_NAME_ALIAS} {
+{$SSL_CERTIFICATE_STRING} {
     # If you want to use basic http-01 (basic, good for one server setup) certificate challenge
     # then uncomment the line below and make sure you have EMAIL_ADDRESS specified in .env file
     # and comment the tls block that contains the dns challenge configuration.

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,30 +1,36 @@
-(custom.domain) {
-    {$DOMAIN_NAME} {
-        tls {$EMAIL_ADDRESS}
-        reverse_proxy nginx:80
-    }
-}
+# Make sure you have DOMAIN_NAME specified in .env file ie. siasky.net, you need it to fetch correct certificates.
+# DOMAIN_NAME_ALIAS is optional, in case you run multiple servers under the same domain like we do for siasky.net
+# then you might want to use it for something server specific that would let you connect to this specific server
+# and disregard load balancer, ie. germany.siasky.net
 
-(siasky.net) {
-    siasky.net, *.siasky.net, *.hns.siasky.net {
-        tls {
-            dns route53 {
-                max_retries 50
-            }
+{$DOMAIN_NAME}, *.{$DOMAIN_NAME}, *.hns.{$DOMAIN_NAME}, {$DOMAIN_NAME_ALIAS}, *.{$DOMAIN_NAME_ALIAS}, *.hns.{$DOMAIN_NAME_ALIAS} {
+    # If you want to use basic http-01 (basic, good for one server setup) certificate challenge
+    # then uncomment the line below and make sure you have EMAIL_ADDRESS specified in .env file
+    # and comment the tls block that contains the dns challenge configuration.
+
+    # tls {$EMAIL_ADDRESS}
+
+    tls {
+        # We are using route53 as our dns provider and it requires additional AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+        # environment variables in .env file. You can use other providers by using specific package from
+        # https://github.com/caddy-dns in the docker/caddy/Dockerfile in place our the route53 one.
+
+        dns route53 {
+            max_retries 50
         }
-        reverse_proxy nginx:80
     }
+
+    reverse_proxy nginx:80
 }
 
-(localhost) {
-    :443 {
-        tls internal {
-            on_demand
-        }
-        reverse_proxy nginx:80
-    }
-}
+# This block below is optional if you want to generate internal certificate for the server ip address.
+# It is useful in case you have services trying to reach the server through ip and not domain like health checks.
+# It will generate internal certificate so browsers will warn you when connecting but that not a problem.
 
-import localhost
-# import custom.domain
-# import siasky.net
+:443 {
+    tls internal {
+        on_demand
+    }
+
+    reverse_proxy nginx:80
+}

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,3 +1,15 @@
+# This block below is optional if you want to generate internal certificate for the server ip address.
+# It is useful in case you have services trying to reach the server through ip and not domain like health checks.
+# It will generate internal certificate so browsers will warn you when connecting but that not a problem.
+
+:443 {
+    tls internal {
+        on_demand
+    }
+
+    reverse_proxy nginx:80
+}
+
 # Make sure you have DOMAIN_NAME specified in .env file ie. siasky.net, you need it to fetch correct certificates.
 # DOMAIN_NAME_ALIAS is optional, in case you run multiple servers under the same domain like we do for siasky.net
 # then you might want to use it for something server specific that would let you connect to this specific server
@@ -18,18 +30,6 @@
         dns route53 {
             max_retries 50
         }
-    }
-
-    reverse_proxy nginx:80
-}
-
-# This block below is optional if you want to generate internal certificate for the server ip address.
-# It is useful in case you have services trying to reach the server through ip and not domain like health checks.
-# It will generate internal certificate so browsers will warn you when connecting but that not a problem.
-
-:443 {
-    tls internal {
-        on_demand
     }
 
     reverse_proxy nginx:80

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,6 +1,6 @@
 # This block below is optional if you want to generate an internal certificate for the server ip address.
 # It is useful in case you have services trying to reach the server through ip and not domain like health checks.
-# It will generate internal certificate so browsers will warn you when connecting but that not a problem.
+# It will generate an internal certificate so browsers will warn you when connecting but that not a problem.
 
 :443 {
     tls internal {

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,4 +1,4 @@
-# This block below is optional if you want to generate internal certificate for the server ip address.
+# This block below is optional if you want to generate an internal certificate for the server ip address.
 # It is useful in case you have services trying to reach the server through ip and not domain like health checks.
 # It will generate internal certificate so browsers will warn you when connecting but that not a problem.
 

--- a/setup-scripts/README.md
+++ b/setup-scripts/README.md
@@ -89,7 +89,7 @@ At this point we have almost everything running, we just need to set up your wal
    - `CLOUDFLARE_AUTH_TOKEN` (optional) if using cloudflare as dns loadbalancer (need to change it in Caddyfile too)
    - `AWS_ACCESS_KEY_ID` (optional) if using route53 as a dns loadbalancer
    - `AWS_SECRET_ACCESS_KEY` (optional) if using route53 as a dns loadbalancer
-   - `PORTAL_NAME` (optional) a string representing name of your portal e.g. `siasky.xyz` or `my skynet portal`
+   - `PORTAL_NAME` a string representing name of your portal e.g. `siasky.xyz` or `my skynet portal`
    - `DISCORD_BOT_TOKEN` (optional) if you're using Discord notifications for health checks and such
    - `SKYNET_DB_USER` (optional) if using `accounts` this is the MongoDB username
    - `SKYNET_DB_PASS` (optional) if using `accounts` this is the MongoDB password

--- a/setup-scripts/README.md
+++ b/setup-scripts/README.md
@@ -48,8 +48,8 @@ You a can now ssh into your machine as the user `user`.
 **Following step will be executed on remote host logged in as a `user`:**
 
 1. `sudo apt-get install git -y` to install git
-1. `git clone https://github.com/NebulousLabs/skynet-webportal`
-1. `cd skynet-webportal` 
+1. `git clone https://github.com/SkynetLabs/skynet-webportal`
+1. `cd skynet-webportal`
 1. run setup scripts in the exact order and provide sudo password when asked (if one of them fails, you can retry just this one before proceeding further)
    1. `/home/user/skynet-webportal/setup-scripts/setup-server.sh`
    1. `/home/user/skynet-webportal/setup-scripts/setup-docker-services.sh`
@@ -81,7 +81,9 @@ At this point we have almost everything running, we just need to set up your wal
 ### Step 4: configuring docker services
 
 1. edit `/home/user/skynet-webportal/.env` and configure following environment variables
+
    - `DOMAIN_NAME` (optional) is your domain name if you have it
+   - `DOMAIN_NAME_ALIAS` (optional) alias to your domain name if you have, set to domain name if not used
    - `EMAIL_ADDRESS` (required) is your email address used for communication regarding SSL certification (required)
    - `SIA_WALLET_PASSWORD` (required) is your wallet password (or seed if you did not set a password)
    - `HSD_API_KEY` (optional) this is a random security key for a handshake integration that gets generated automatically
@@ -101,7 +103,10 @@ At this point we have almost everything running, we just need to set up your wal
      with path to the location in the bucket where we want to store the daily backups.
 
 1. if you have a custom domain and you configured it in `DOMAIN_NAME`, edit `/home/user/skynet-webportal/docker/caddy/Caddyfile` and uncomment `import custom.domain`
-1. only for siasky.net domain instances: edit `/home/user/skynet-webportal/docker/caddy/Caddyfile`, uncomment `import siasky.net`
+1. edit `/home/user/skynet-webportal/docker/caddy/Caddyfile`:
+
+   - if you are not running our uncomment `import siasky.net`
+
 1. `docker-compose up -d` to restart the services so they pick up new env variables
 1. `docker exec caddy caddy reload --config /etc/caddy/Caddyfile` to reload Caddyfile configuration
 1. add your custom Kratos configuration to `/home/user/skynet-webportal/docker/kratos/config/kratos.yml` (in particular, the credentials for your mail server should be here, rather than in your source control). For a starting point you can take `docker/kratos/config/kratos.yml.sample`.

--- a/setup-scripts/README.md
+++ b/setup-scripts/README.md
@@ -82,15 +82,14 @@ At this point we have almost everything running, we just need to set up your wal
 
 1. edit `/home/user/skynet-webportal/.env` and configure following environment variables
 
-   - `DOMAIN_NAME` (optional) is your domain name if you have it
-   - `DOMAIN_NAME_ALIAS` (optional) alias to your domain name if you have, set to domain name if not used
-   - `EMAIL_ADDRESS` (required) is your email address used for communication regarding SSL certification (required)
-   - `SIA_WALLET_PASSWORD` (required) is your wallet password (or seed if you did not set a password)
-   - `HSD_API_KEY` (optional) this is a random security key for a handshake integration that gets generated automatically
+   - `SSL_CERTIFICATE_STRING` is a list of comma separated paths that caddy will generate ssl certificates for
+   - `EMAIL_ADDRESS` is your email address used for communication regarding SSL certification (required if you're using http-01 challenge)
+   - `SIA_WALLET_PASSWORD` is your wallet password (or seed if you did not set a password)
+   - `HSD_API_KEY` this is a random security key for a handshake integration that gets generated automatically
    - `CLOUDFLARE_AUTH_TOKEN` (optional) if using cloudflare as dns loadbalancer (need to change it in Caddyfile too)
    - `AWS_ACCESS_KEY_ID` (optional) if using route53 as a dns loadbalancer
    - `AWS_SECRET_ACCESS_KEY` (optional) if using route53 as a dns loadbalancer
-   - `PORTAL_NAME` (optional) e.g. `siasky.xyz`
+   - `PORTAL_NAME` (optional) a string representing name of your portal e.g. `siasky.xyz` or `my skynet portal`
    - `DISCORD_BOT_TOKEN` (optional) if you're using Discord notifications for health checks and such
    - `SKYNET_DB_USER` (optional) if using `accounts` this is the MongoDB username
    - `SKYNET_DB_PASS` (optional) if using `accounts` this is the MongoDB password
@@ -101,11 +100,6 @@ At this point we have almost everything running, we just need to set up your wal
    - `COOKIE_ENC_KEY` (optional) if using `accounts` encryption key, at least 32 bytes
    - `S3_BACKUP_PATH` (optional) is using `accounts` and backing up the databases to S3. This path should be an S3 bucket
      with path to the location in the bucket where we want to store the daily backups.
-
-1. if you have a custom domain and you configured it in `DOMAIN_NAME`, edit `/home/user/skynet-webportal/docker/caddy/Caddyfile` and uncomment `import custom.domain`
-1. edit `/home/user/skynet-webportal/docker/caddy/Caddyfile`:
-
-   - if you are not running our uncomment `import siasky.net`
 
 1. `docker-compose up -d` to restart the services so they pick up new env variables
 1. `docker exec caddy caddy reload --config /etc/caddy/Caddyfile` to reload Caddyfile configuration
@@ -125,15 +119,16 @@ To configure this on your portal, you have to make sure to configure the followi
 
 We need to ensure SSL encryption for skapps that are accessed through their
 subdomain, therefore we need to have a wildcard certificate. This is very easily
-achieved using Caddy.
+achieved using wildcard certificates in Caddy.
 
 ```
-(siasky.net) {
-    siasky.net, *.siasky.net, *.hns.siasky.net {
-        ...
-    }
+{$SSL_CERTIFICATE_STRING} {
+    ...
 }
 ```
+
+Where `SSL_CERTIFICATE_STRING` environment variable should contain the wildcard for subdomains (ie. _.example.com) and
+wildcard for hns subdomains (ie. _.hns.example.com).
 
 (see [docker/caddy/Caddyfile](../docker/Caddy/Caddyfile))
 

--- a/setup-scripts/setup-docker-services.sh
+++ b/setup-scripts/setup-docker-services.sh
@@ -21,8 +21,7 @@ sudo chmod +x /usr/local/bin/docker-compose
 docker-compose --version # sanity check
 
 # Create dummy .env file for docker-compose usage with variables
-# * DOMAIN_NAME - the domain name your server is using ie. example.com
-# * DOMAIN_NAME_ALIAS - the domain name alias you might want to give to this specific server ie. germany.example.com
+# * SSL_CERTIFICATE_STRING - certificate string that will be used to generate ssl certificates, read more in docker/caddy/Caddyfile
 # * SKYNET_PORTAL_API - absolute url to the portal api ie. https://example.com
 # * SKYNET_DASHBOARD_URL - (optional) absolute url to the portal dashboard ie. https://account.example.com
 # * EMAIL_ADDRESS - this is the administrator contact email you need to supply for communication regarding SSL certification
@@ -44,7 +43,7 @@ docker-compose --version # sanity check
 # * CR_CLUSTER_NODES - (optional) if using `accounts` the list of servers (with ports) which make up your CockroachDB cluster, e.g. `helsinki.siasky.net:26257,germany.siasky.net:26257,us-east.siasky.net:26257`
 if ! [ -f /home/user/skynet-webportal/.env ]; then
     HSD_API_KEY=$(openssl rand -base64 32) # generate safe random key for handshake
-    printf "DOMAIN_NAME=example.com\nDOMAIN_NAME_ALIAS=example.com\nSKYNET_PORTAL_API=https://example.com\nSKYNET_DASHBOARD_URL=https://account.example.com\nEMAIL_ADDRESS=email@example.com\nSIA_WALLET_PASSWORD=\nHSD_API_KEY=${HSD_API_KEY}\nCLOUDFLARE_AUTH_TOKEN=\nAWS_ACCESS_KEY_ID=\nAWS_SECRET_ACCESS_KEY=\nPORTAL_NAME=\nDISCORD_BOT_TOKEN=\n" > /home/user/skynet-webportal/.env
+    printf "SSL_CERTIFICATE_STRING=example.com, *.example.com, *.hns.example.com\nSKYNET_PORTAL_API=https://example.com\nSKYNET_DASHBOARD_URL=https://account.example.com\nEMAIL_ADDRESS=email@example.com\nSIA_WALLET_PASSWORD=\nHSD_API_KEY=${HSD_API_KEY}\nCLOUDFLARE_AUTH_TOKEN=\nAWS_ACCESS_KEY_ID=\nAWS_SECRET_ACCESS_KEY=\nPORTAL_NAME=\nDISCORD_BOT_TOKEN=\n" > /home/user/skynet-webportal/.env
 fi
 
 # Start docker container with nginx and client

--- a/setup-scripts/setup-docker-services.sh
+++ b/setup-scripts/setup-docker-services.sh
@@ -22,6 +22,7 @@ docker-compose --version # sanity check
 
 # Create dummy .env file for docker-compose usage with variables
 # * DOMAIN_NAME - the domain name your server is using ie. example.com
+# * DOMAIN_NAME_ALIAS - the domain name alias you might want to give to this specific server ie. germany.example.com
 # * SKYNET_PORTAL_API - absolute url to the portal api ie. https://example.com
 # * SKYNET_DASHBOARD_URL - (optional) absolute url to the portal dashboard ie. https://account.example.com
 # * EMAIL_ADDRESS - this is the administrator contact email you need to supply for communication regarding SSL certification
@@ -43,7 +44,7 @@ docker-compose --version # sanity check
 # * CR_CLUSTER_NODES - (optional) if using `accounts` the list of servers (with ports) which make up your CockroachDB cluster, e.g. `helsinki.siasky.net:26257,germany.siasky.net:26257,us-east.siasky.net:26257`
 if ! [ -f /home/user/skynet-webportal/.env ]; then
     HSD_API_KEY=$(openssl rand -base64 32) # generate safe random key for handshake
-    printf "DOMAIN_NAME=example.com\nSKYNET_PORTAL_API=https://example.com\nSKYNET_DASHBOARD_URL=https://account.example.com\nEMAIL_ADDRESS=email@example.com\nSIA_WALLET_PASSWORD=\nHSD_API_KEY=${HSD_API_KEY}\nCLOUDFLARE_AUTH_TOKEN=\nAWS_ACCESS_KEY_ID=\nAWS_SECRET_ACCESS_KEY=\nPORTAL_NAME=\nDISCORD_BOT_TOKEN=\n" > /home/user/skynet-webportal/.env
+    printf "DOMAIN_NAME=example.com\nDOMAIN_NAME_ALIAS=example.com\nSKYNET_PORTAL_API=https://example.com\nSKYNET_DASHBOARD_URL=https://account.example.com\nEMAIL_ADDRESS=email@example.com\nSIA_WALLET_PASSWORD=\nHSD_API_KEY=${HSD_API_KEY}\nCLOUDFLARE_AUTH_TOKEN=\nAWS_ACCESS_KEY_ID=\nAWS_SECRET_ACCESS_KEY=\nPORTAL_NAME=\nDISCORD_BOT_TOKEN=\n" > /home/user/skynet-webportal/.env
 fi
 
 # Start docker container with nginx and client


### PR DESCRIPTION
**IMPORTANT UPGRADE NOTES** We need to make sure to replace `DOMAIN_NAME` with `SSL_CERTIFICATE_STRING`.

On siasky.net production server it would look like:

`SSL_CERTIFICATE_STRING=siasky.net, *.siasky.net, *.hns.siasky.net, *.germany.siasky.net, *.hns.germany.siasky.net`

On development servers, since we're not using aliases for specific servers, the example would look like:

`SSL_CERTIFICATE_STRING=example.com, *.example.com, *.hns.example.com`