### PR TITLE
Add skyd tracing with Jaeger

### DIFF
--- a/docker-compose.jaeger.yml
+++ b/docker-compose.jaeger.yml
@@ -21,10 +21,10 @@ services:
     command: [ "--reporter.grpc.host-port=jaeger-collector:14250", "--reporter.grpc.retry.max=1000" ]
     container_name: jaeger-agent
     restart: on-failure
-    ports:
-      - "127.0.0.1:6831:6831/udp"
-      - "127.0.0.1:6832:6832/udp"
-      - "127.0.0.1:5778:5778"
+    expose:
+      - 6831
+      - 6832
+      - 5778
     environment:
       - LOG_LEVEL=debug
     networks:
@@ -38,10 +38,10 @@ services:
     command: [ "--es.num-shards=1", "--es.num-replicas=0", "--es.server-urls=http://elasticsearch:9200" ]
     container_name: jaeger-collector
     restart: on-failure
-    ports:
-      - "127.0.0.1:14269:14269"
-      - "127.0.0.1:14268:14268"
-      - "127.0.0.1:14250:14250"
+    expose:
+      - 14269
+      - 14268
+      - 14250
     environment:
       - SPAN_STORAGE_TYPE=elasticsearch
       - LOG_LEVEL=debug
@@ -56,9 +56,9 @@ services:
     command: [ "--es.num-shards=1", "--es.num-replicas=0", "--es.server-urls=http://elasticsearch:9200" ]
     container_name: jaeger-query
     restart: on-failure
-    ports:
-      - "127.0.0.1:16686:16686"
-      - "127.0.0.1:16687:16687"
+    expose:
+      - 16686
+      - 16687
     environment:
       - SPAN_STORAGE_TYPE=elasticsearch
       - LOG_LEVEL=debug
@@ -77,8 +77,8 @@ services:
     volumes:
       # This dir needs to be chowned to 1000:1000
       - ./docker/data/elasticsearch/data:/usr/share/elasticsearch/data
-    ports:
-      - "127.0.0.1:9200:9200/tcp"
+    expose:
+      - 9200
     networks:
       shared:
         ipv4_address: 10.10.10.93

--- a/docker-compose.jaeger.yml
+++ b/docker-compose.jaeger.yml
@@ -78,10 +78,6 @@ services:
     restart: on-failure
     environment:
       - discovery.type=single-node
-      # This prevents elasticsearch from using swap.
-      # See https://www.elastic.co/guide/en/elasticsearch/reference/master/setup-configuration-memory.html#setup-configuration-memory
-#      - bootstrap.memory_lock=true
-#      - "ES_JAVA_OPTS=-Xms4g -Xmx4g"
     volumes:
       # This dir needs to be chowned to 1000:1000
       - ./docker/data/elasticsearch/data:/usr/share/elasticsearch/data

--- a/docker-compose.jaeger.yml
+++ b/docker-compose.jaeger.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.7'
 
 services:
   sia:

--- a/docker-compose.jaeger.yml
+++ b/docker-compose.jaeger.yml
@@ -56,8 +56,9 @@ services:
     command: [ "--es.num-shards=1", "--es.num-replicas=0", "--es.server-urls=http://elasticsearch:9200" ]
     container_name: jaeger-query
     restart: on-failure
+    ports:
+      - "127.0.0.1:16686:16686"
     expose:
-      - 16686
       - 16687
     environment:
       - SPAN_STORAGE_TYPE=elasticsearch

--- a/docker-compose.jaeger.yml
+++ b/docker-compose.jaeger.yml
@@ -8,8 +8,8 @@ services:
       # Configuration
       # See https://github.com/jaegertracing/jaeger-client-go#environment-variables
       # for all options.
-      - JAEGER_SAMPLER_TYPE=const
-      - JAEGER_SAMPLER_PARAM=1
+      - JAEGER_SAMPLER_TYPE=probabilistic
+      - JAEGER_SAMPLER_PARAM=0.1
       - JAEGER_AGENT_HOST=jaeger-agent
       - JAEGER_AGENT_PORT=6831
       - JAEGER_REPORTER_LOG_SPANS=false

--- a/docker-compose.jaeger.yml
+++ b/docker-compose.jaeger.yml
@@ -1,0 +1,85 @@
+version: '3'
+
+services:
+  sia:
+    environment:
+      - SIA_MODULES=gctwr
+      - JAEGER_DISABLED="${JAEGER_DISABLED:-false}"   # Enable/Disable tracing
+      - JAEGER_SERVICE_NAME="${PORTAL_NAME:-Skyd}"    # change to e.g. eu-ger-1
+      # Configuration
+      # See https://github.com/jaegertracing/jaeger-client-go#environment-variables
+      # for all options.
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
+      - JAEGER_AGENT_HOST=jaeger-agent
+      - JAEGER_AGENT_PORT=6831
+      - JAEGER_REPORTER_LOG_SPANS=false
+    depends_on:
+      - jaeger-agent
+
+  jaeger-agent:
+    image: jaegertracing/jaeger-agent
+    command: [ "--reporter.grpc.host-port=jaeger-collector:14250", "--reporter.grpc.retry.max=1000" ]
+    container_name: jaeger-agent
+    restart: on-failure
+    ports:
+      - "5775:5775/udp"
+      - "6831:6831/udp"
+      - "6832:6832/udp"
+      - "5778:5778"
+    environment:
+      - LOG_LEVEL=debug
+    networks:
+      shared:
+        ipv4_address: 10.10.10.92
+    depends_on:
+      - jaeger-collector
+
+  jaeger-collector:
+    image: jaegertracing/jaeger-collector
+    command: [ "--es.num-shards=1", "--es.num-replicas=0", "--es.server-urls=http://elasticsearch:9200", "--collector.zipkin.host-port=:9411" ]
+    container_name: jaeger-collector
+    restart: on-failure
+    ports:
+      - "14269"
+      - "14268:14268"
+      - "14250"
+      - "9411:9411"
+    environment:
+      - SPAN_STORAGE_TYPE=elasticsearch
+      - LOG_LEVEL=debug
+    networks:
+      shared:
+        ipv4_address: 10.10.10.90
+    depends_on:
+      - elasticsearch
+
+  jaeger-query:
+    image: jaegertracing/jaeger-query
+    command: [ "--es.num-shards=1", "--es.num-replicas=0", "--es.server-urls=http://elasticsearch:9200" ]
+    container_name: jaeger-query
+    restart: on-failure
+    ports:
+      - "16686:16686"
+      - "16687"
+    environment:
+      - SPAN_STORAGE_TYPE=elasticsearch
+      - LOG_LEVEL=debug
+    networks:
+      shared:
+        ipv4_address: 10.10.10.91
+    depends_on:
+      - elasticsearch
+
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.15
+    container_name: elasticsearch
+    restart: on-failure
+    environment:
+      - discovery.type=single-node
+    ports:
+      - "9200:9200/tcp"
+    networks:
+      shared:
+        ipv4_address: 10.10.10.93

--- a/docker-compose.jaeger.yml
+++ b/docker-compose.jaeger.yml
@@ -78,8 +78,9 @@ services:
     volumes:
       # This dir needs to be chowned to 1000:1000
       - ./docker/data/elasticsearch/data:/usr/share/elasticsearch/data
-    expose:
-      - 9200
+    ports:
+      # We need to expose this port, so we can prune the indexes.
+      - "127.0.0.1:9200:9200"
     networks:
       shared:
         ipv4_address: 10.10.10.93

--- a/docker-compose.jaeger.yml
+++ b/docker-compose.jaeger.yml
@@ -80,10 +80,11 @@ services:
       - discovery.type=single-node
       # This prevents elasticsearch from using swap.
       # See https://www.elastic.co/guide/en/elasticsearch/reference/master/setup-configuration-memory.html#setup-configuration-memory
-      - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms4g -Xmx4g"
+#      - bootstrap.memory_lock=true
+#      - "ES_JAVA_OPTS=-Xms4g -Xmx4g"
     volumes:
-      - ./docker/data/elasticsearch:/usr/share/elasticsearch/data
+      # This dir needs to be chowned to 1000:1000
+      - ./docker/data/elasticsearch/data:/usr/share/elasticsearch/data
     ports:
       - "127.0.0.1:9200:9200/tcp"
     networks:

--- a/docker-compose.jaeger.yml
+++ b/docker-compose.jaeger.yml
@@ -4,8 +4,8 @@ services:
   sia:
     environment:
       - SIA_MODULES=gctwr
-      - JAEGER_DISABLED="${JAEGER_DISABLED:-false}"   # Enable/Disable tracing
-      - JAEGER_SERVICE_NAME="${PORTAL_NAME:-Skyd}"    # change to e.g. eu-ger-1
+      - JAEGER_DISABLED=${JAEGER_DISABLED:-true}  # Enable/Disable tracing
+      - JAEGER_SERVICE_NAME=${PORTAL_NAME:-Skyd}  # change to e.g. eu-ger-1
       # Configuration
       # See https://github.com/jaegertracing/jaeger-client-go#environment-variables
       # for all options.
@@ -78,8 +78,14 @@ services:
     restart: on-failure
     environment:
       - discovery.type=single-node
+      # This prevents elasticsearch from using swap.
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/master/setup-configuration-memory.html#setup-configuration-memory
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms4g -Xmx4g"
+    volumes:
+      - ./docker/data/elasticsearch:/usr/share/elasticsearch/data
     ports:
-      - "9200:9200/tcp"
+      - "127.0.0.1:9200:9200/tcp"
     networks:
       shared:
         ipv4_address: 10.10.10.93

--- a/docker-compose.jaeger.yml
+++ b/docker-compose.jaeger.yml
@@ -3,7 +3,6 @@ version: '3.7'
 services:
   sia:
     environment:
-      - SIA_MODULES=gctwr
       - JAEGER_DISABLED=${JAEGER_DISABLED:-true}  # Enable/Disable tracing
       - JAEGER_SERVICE_NAME=${PORTAL_NAME:-Skyd}  # change to e.g. eu-ger-1
       # Configuration
@@ -23,45 +22,26 @@ services:
     container_name: jaeger-agent
     restart: on-failure
     ports:
-      - "5775:5775/udp"
-      - "6831:6831/udp"
-      - "6832:6832/udp"
-      - "5778:5778"
+      - "127.0.0.1:6831:6831/udp"
+      - "127.0.0.1:6832:6832/udp"
+      - "127.0.0.1:5778:5778"
     environment:
-      - LOG_LEVEL=debug
-    networks:
-      shared:
-        ipv4_address: 10.10.10.92
-    depends_on:
-      - jaeger-collector
-
-  jaeger-collector:
-    image: jaegertracing/jaeger-collector
-    command: [ "--es.num-shards=1", "--es.num-replicas=0", "--es.server-urls=http://elasticsearch:9200", "--collector.zipkin.host-port=:9411" ]
-    container_name: jaeger-collector
-    restart: on-failure
-    ports:
-      - "14269"
-      - "14268:14268"
-      - "14250"
-      - "9411:9411"
-    environment:
-      - SPAN_STORAGE_TYPE=elasticsearch
       - LOG_LEVEL=debug
     networks:
       shared:
         ipv4_address: 10.10.10.90
     depends_on:
-      - elasticsearch
+      - jaeger-collector
 
-  jaeger-query:
-    image: jaegertracing/jaeger-query
+  jaeger-collector:
+    image: jaegertracing/jaeger-collector
     command: [ "--es.num-shards=1", "--es.num-replicas=0", "--es.server-urls=http://elasticsearch:9200" ]
-    container_name: jaeger-query
+    container_name: jaeger-collector
     restart: on-failure
     ports:
-      - "16686:16686"
-      - "16687"
+      - "127.0.0.1:14269:14269"
+      - "127.0.0.1:14268:14268"
+      - "127.0.0.1:14250:14250"
     environment:
       - SPAN_STORAGE_TYPE=elasticsearch
       - LOG_LEVEL=debug
@@ -71,6 +51,22 @@ services:
     depends_on:
       - elasticsearch
 
+  jaeger-query:
+    image: jaegertracing/jaeger-query
+    command: [ "--es.num-shards=1", "--es.num-replicas=0", "--es.server-urls=http://elasticsearch:9200" ]
+    container_name: jaeger-query
+    restart: on-failure
+    ports:
+      - "127.0.0.1:16686:16686"
+      - "127.0.0.1:16687:16687"
+    environment:
+      - SPAN_STORAGE_TYPE=elasticsearch
+      - LOG_LEVEL=debug
+    networks:
+      shared:
+        ipv4_address: 10.10.10.92
+    depends_on:
+      - elasticsearch
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.15

--- a/scripts/es_cleaner.py
+++ b/scripts/es_cleaner.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+import curator
+import elasticsearch
+import os
+import ssl
+import sys
+
+TIMEOUT=120
+
+def main():
+    if len(sys.argv) != 3:
+        print('USAGE: [INDEX_PREFIX=(default "")] [ARCHIVE=(default false)] ... {} NUM_OF_DAYS http://HOSTNAME[:PORT]'.format(sys.argv[0]))
+        print('NUM_OF_DAYS ... delete indices that are older than the given number of days.')
+        print('HOSTNAME ... specifies which Elasticsearch hosts URL to search and delete indices from.')
+        print('TIMEOUT ...  number of seconds to wait for master node response.'.format(TIMEOUT))
+        print('INDEX_PREFIX ... specifies index prefix.')
+        print('INDEX_DATE_SEPARATOR ... specifies index date separator.')
+        print('ARCHIVE ... specifies whether to remove archive indices (only works for rollover) (default false).')
+        print('ROLLOVER ... specifies whether to remove indices created by rollover (default false).')
+        print('ES_USERNAME ... The username required by Elasticsearch.')
+        print('ES_PASSWORD ... The password required by Elasticsearch.')
+        print('ES_TLS ... enable TLS (default false).')
+        print('ES_TLS_CA ... Path to TLS CA file.')
+        print('ES_TLS_CERT ... Path to TLS certificate file.')
+        print('ES_TLS_KEY ... Path to TLS key file.')
+        print('ES_TLS_SKIP_HOST_VERIFY ... (insecure) Skip server\'s certificate chain and host name verification.')
+        sys.exit(1)
+
+    client = create_client(os.getenv("ES_USERNAME"), os.getenv("ES_PASSWORD"), str2bool(os.getenv("ES_TLS", 'false')), os.getenv("ES_TLS_CA"), os.getenv("ES_TLS_CERT"), os.getenv("ES_TLS_KEY"), str2bool(os.getenv("ES_TLS_SKIP_HOST_VERIFY", 'false')))
+    ilo = curator.IndexList(client)
+    empty_list(ilo, 'Elasticsearch has no indices')
+
+    prefix = os.getenv("INDEX_PREFIX", '')
+    if prefix != '':
+        prefix += '-'
+    separator = os.getenv("INDEX_DATE_SEPARATOR", '-')
+
+    if str2bool(os.getenv("ARCHIVE", 'false')):
+        filter_archive_indices_rollover(ilo, prefix)
+    else:
+        if str2bool(os.getenv("ROLLOVER", 'false')):
+            filter_main_indices_rollover(ilo, prefix)
+        else:
+            filter_main_indices(ilo, prefix, separator)
+
+    empty_list(ilo, 'No indices to delete')
+
+    for index in ilo.working_list():
+        print("Removing", index)
+    timeout = int(os.getenv("TIMEOUT", TIMEOUT))
+    delete_indices = curator.DeleteIndices(ilo, master_timeout=timeout)
+    delete_indices.do_action()
+
+
+def filter_main_indices(ilo, prefix, separator):
+    date_regex = "\d{4}" + separator + "\d{2}" + separator + "\d{2}"
+    time_string = "%Y" + separator + "%m" + separator + "%d"
+
+    ilo.filter_by_regex(kind='regex', value=prefix + "jaeger-(span|service|dependencies)-" + date_regex)
+    empty_list(ilo, "No indices to delete")
+    # This excludes archive index as we use source='name'
+    # source `creation_date` would include archive index
+    ilo.filter_by_age(source='name', direction='older', timestring=time_string, unit='days', unit_count=int(sys.argv[1]))
+
+
+def filter_main_indices_rollover(ilo, prefix):
+    ilo.filter_by_regex(kind='regex', value=prefix + "jaeger-(span|service)-\d{6}")
+    empty_list(ilo, "No indices to delete")
+    # do not remove active write indices
+    ilo.filter_by_alias(aliases=[prefix + 'jaeger-span-write'], exclude=True)
+    empty_list(ilo, "No indices to delete")
+    ilo.filter_by_alias(aliases=[prefix + 'jaeger-service-write'], exclude=True)
+    empty_list(ilo, "No indices to delete")
+    ilo.filter_by_age(source='creation_date', direction='older', unit='days', unit_count=int(sys.argv[1]))
+
+
+def filter_archive_indices_rollover(ilo, prefix):
+    # Remove only rollover archive indices
+    # Do not remove active write archive index
+    ilo.filter_by_regex(kind='regex', value=prefix + "jaeger-span-archive-\d{6}")
+    empty_list(ilo, "No indices to delete")
+    ilo.filter_by_alias(aliases=[prefix + 'jaeger-span-archive-write'], exclude=True)
+    empty_list(ilo, "No indices to delete")
+    ilo.filter_by_age(source='creation_date', direction='older', unit='days', unit_count=int(sys.argv[1]))
+
+
+def empty_list(ilo, error_msg):
+    try:
+        ilo.empty_list_check()
+    except curator.NoIndices:
+        print(error_msg)
+        sys.exit(0)
+
+
+def str2bool(v):
+    return v.lower() in ('true', '1')
+
+
+def create_client(username, password, tls, ca, cert, key, skipHostVerify):
+    context = ssl.create_default_context()
+    if ca is not None:
+        context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH, cafile=ca)
+    elif skipHostVerify:
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+    if username is not None and password is not None:
+        return elasticsearch.Elasticsearch(sys.argv[2:], http_auth=(username, password), ssl_context=context)
+    elif tls:
+        context.load_cert_chain(certfile=cert, keyfile=key)
+        return elasticsearch.Elasticsearch(sys.argv[2:], ssl_context=context)
+    else:
+        return elasticsearch.Elasticsearch(sys.argv[2:], ssl_context=context)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup-scripts/setup-health-check-scripts.sh
+++ b/setup-scripts/setup-health-check-scripts.sh
@@ -5,7 +5,7 @@ set -e # exit on first error
 sudo apt-get update
 sudo apt-get -y install python3-pip
 
-pip3 install discord.py python-dotenv requests
+pip3 install discord.py python-dotenv requests elasticsearch-curator
 
 # add cron entries to user crontab
 crontab -u user /home/user/skynet-webportal/setup-scripts/support/crontab


### PR DESCRIPTION
## Overview

Add tracing for `skyd`.

## Details

We need to be able to quickly answer questions like "Why is this call slow?" in real time. In order to be able to do that we need to know exactly what is happening with user requests going through the stack and specifically what is happening within `skyd`.

This PR introduces Jaeger - a tracing tool to which `skyd` will send information about its internal state. Jaeger will persist this data on disk with the help of Elasticsearch and will expose a nice UI at local port 16686 (local because there is no authentication).

The integration with Jaeger requires additional instrumentation in `skyd` which is available on branch `chris/tracing-sample` and will be extended and merged into `master` in the future.

The integration with Jaeger is disabled in `skyd` by default and will only be enabled if the env var `JAEGER_DISABLED` is set to `false`.

## Caveats

Elasticsearch seems to be running as a regular user in its container and therefore cannot write to regular volumes unless they are set up with specific ownership or permissions. That's why for it to work we need to specifically create and `chown` its local data directory at `./docker/data/elasticsearch/data` to `1000:1000`.