### PR TITLE
disable api access from subdomained skapps

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -72,23 +72,23 @@ server {
 	rewrite ^/skynet/blacklist /skynet/blocklist permanent;
 	rewrite ^/account/(.*) https://account.$domain.$tld/$1 permanent;
 
+	# This is only safe workaround to reroute based on some conditions
+	# See https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/
+	recursive_error_pages on;
+
+	# redirect links with base32 encoded skylink in subdomain
+	error_page 460 = @base32_subdomain;
+	if ($base32_subdomain != "") {
+		return 460;
+	}
+
+	# redirect links with handshake domain on hns subdomain
+	error_page 461 = @hns_domain;
+	if ($hns_domain != "") {
+		return 461;
+	}
+
 	location / {
-		# This is only safe workaround to reroute based on some conditions
-		# See https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/
-		recursive_error_pages on;
-
-		# redirect links with base32 encoded skylink in subdomain
-		error_page 460 = @base32_subdomain;
-		if ($base32_subdomain != "") {
-			return 460;
-		}
-
-		# redirect links with handshake domain on hns subdomain
-		error_page 461 = @hns_domain;
-		if ($hns_domain != "") {
-			return 461;
-		}
-
 		include /etc/nginx/conf.d/include/cors;
 
 		proxy_pass http://website:9000;


### PR DESCRIPTION
**BREAKING CHANGE** 

Due to security concerns, we're disabling api access from skapp subdomains.


- `POST https://foo.hns.siasky.net/skynet/skyfile` - will not work, use `POST https://siasky.net`
- `GET https://foo.hns.siasky.net/3ACpC9Umme41zlWUgMQh1fw0sNwgWwyfDDhRQ9Sppz9hjQ` will access foo hns domain and try to access directory `3ACpC9Umme41zlWUgMQh1fw0sNwgWwyfDDhRQ9Sppz9hjQ`, it will not load content from skylink `3ACpC9Umme41zlWUgMQh1fw0sNwgWwyfDDhRQ9Sppz9hjQ` like it used to
- `GET https://foo.hns.siasky.net/hns/bar` - it will load foo hns domain content and not `bar` hns domain content like it used to

Current version of skynet-js supports all of that already so instead of composing links yourself please defer to skynet-js to compose them for you - it will correctly route api requests to an api address.


The above applies also to skylinks in subdomains.
