### PR TITLE
decrease cache time on /skynet/stats from 10 minutes to 1 minute

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -147,7 +147,7 @@ server {
 		}
 
 		proxy_cache skynet;
-		proxy_cache_valid any 10m; # cache stats for 10 minutes
+		proxy_cache_valid any 1m; # cache stats for 1 minute
 		proxy_set_header User-Agent: Sia-Agent;
 		proxy_read_timeout 5m; # extend the read timeout
 		proxy_pass http://siad/skynet/stats;


### PR DESCRIPTION
due to performance improvements we can decrease (or actually remove completely if it works out) cache time on /skynet/stats endpoint