### PR TITLE
copy over all /go/bin/ artifacts

### DIFF
--- a/docker/sia/Dockerfile
+++ b/docker/sia/Dockerfile
@@ -10,8 +10,7 @@ RUN make release --directory Sia
 
 FROM nebulouslabs/sia:latest
 
-COPY --from=sia-builder /go/bin/sky* /usr/bin/
-COPY --from=sia-builder /go/bin/sia* /usr/bin/
+COPY --from=sia-builder /go/bin/ /usr/bin/
 
 RUN mv /usr/bin/skyd /usr/bin/siad || true && \
     mv /usr/bin/skyc /usr/bin/siac || true


### PR DESCRIPTION
Fixes following error when building sia with `portal-latest` branch
```
Step 9/10 : COPY --from=sia-builder /go/bin/sia* /usr/bin/
COPY failed: no source files were specified
ERROR: Service 'sia' failed to build : Build failed
```

After the fix:
```
Step 8/9 : COPY --from=sia-builder /go/bin/ /usr/bin/
 ---> 2e051116a6ed
Step 9/9 : RUN mv /usr/bin/skyd /usr/bin/siad || true &&     mv /usr/bin/skyc /usr/bin/siac || true
 ---> Running in c33ced7c7791
Removing intermediate container c33ced7c7791
 ---> 7c72cd921773
Successfully built 7c72cd921773
Successfully tagged skynet-webportal_sia:latest
```