### PR TITLE
Extend critical health checks

### DIFF
--- a/packages/health-check/Dockerfile
+++ b/packages/health-check/Dockerfile
@@ -2,13 +2,13 @@ FROM node:16.1.0-alpine
 
 WORKDIR /usr/app
 
+RUN echo '*/5 * * * * /usr/app/cli/run critical > /dev/stdout' >> /etc/crontabs/root
+RUN echo '0 * * * * /usr/app/cli/run extended > /dev/stdout' >> /etc/crontabs/root
+
 COPY package.json .
 RUN yarn --no-lockfile
 COPY src src
 COPY cli cli
-
-RUN echo '*/5 * * * * /usr/app/cli/run critical > /dev/stdout' >> /etc/crontabs/root
-RUN echo '0 * * * * /usr/app/cli/run extended > /dev/stdout' >> /etc/crontabs/root
 
 EXPOSE 3100
 ENV NODE_ENV production

--- a/packages/health-check/Dockerfile
+++ b/packages/health-check/Dockerfile
@@ -2,7 +2,10 @@ FROM node:16.1.0-alpine
 
 WORKDIR /usr/app
 
+# schedule critical checks to run every 5 minutes (any failures will disable server)
 RUN echo '*/5 * * * * /usr/app/cli/run critical > /dev/stdout' >> /etc/crontabs/root
+
+# schedule extended checks to run on every hour (optional checks, report only)
 RUN echo '0 * * * * /usr/app/cli/run extended > /dev/stdout' >> /etc/crontabs/root
 
 COPY package.json .
@@ -12,4 +15,10 @@ COPY cli cli
 
 EXPOSE 3100
 ENV NODE_ENV production
+
+# command consists of 3 parts:
+# 1. starting crond
+# 2. aliasing siasky.net and account.siasky.net with current server ip so health checks 
+#    test portal end-to-end on prod domain (important for testing ssl certificates)
+# 3. running api service
 CMD [ "sh", "-c", "crond ; echo $(node src/whatismyip.js) siasky.net account.siasky.net >> /etc/hosts ; node --max-http-header-size=64000 src/index.js" ]

--- a/packages/health-check/src/checks/critical.js
+++ b/packages/health-check/src/checks/critical.js
@@ -59,7 +59,9 @@ async function handshakeSubdomainCheck(done) {
 
 // handshakeSubdomainCheck returns the result of accessing account dashboard website
 async function accountWebsiteCheck(done) {
-  return genericAccessCheck("account_website", process.env.SKYNET_DASHBOARD_URL, done);
+  const url = `${process.env.SKYNET_DASHBOARD_URL}/auth/login`;
+
+  return genericAccessCheck("account_website", url, done);
 }
 
 // accountHealthCheck returns the result of accounts service health checks

--- a/packages/health-check/src/checks/critical.js
+++ b/packages/health-check/src/checks/critical.js
@@ -47,7 +47,7 @@ async function downloadCheck(done) {
 async function skylinkSubdomainCheck(done) {
   const url = await skynetClient.getSkylinkUrl(exampleSkylink, { subdomain: true });
 
-  return genericAccessCheck("skylink_via_subdomain", done);
+  return genericAccessCheck("skylink_via_subdomain", url, done);
 }
 
 // skylinkSubdomainCheck returns the result of downloading the hard coded link via subdomain

--- a/packages/health-check/src/checks/critical.js
+++ b/packages/health-check/src/checks/critical.js
@@ -50,13 +50,19 @@ async function skylinkSubdomainCheck(done) {
   return genericAccessCheck("skylink_via_subdomain", url, done);
 }
 
-// skylinkSubdomainCheck returns the result of downloading the hard coded link via subdomain
+// handshakeSubdomainCheck returns the result of downloading the skylink via handshake domain
 async function handshakeSubdomainCheck(done) {
   const url = await skynetClient.getHnsUrl("note-to-self", { subdomain: true });
 
   return genericAccessCheck("hns_via_subdomain", url, done);
 }
 
+// handshakeSubdomainCheck returns the result of accessing account dashboard website
+async function accountWebsiteCheck(done) {
+  return genericAccessCheck("account_website", process.env.SKYNET_DASHBOARD_URL, done);
+}
+
+// accountHealthCheck returns the result of accounts service health checks
 async function accountHealthCheck(done) {
   const time = process.hrtime();
   const data = { up: false };
@@ -75,11 +81,7 @@ async function accountHealthCheck(done) {
     data.ip = error?.response?.ip ?? null;
   }
 
-  done({
-    name: "account_health",
-    time: calculateElapsedTime(time),
-    ...data,
-  });
+  done({ name: "accounts", time: calculateElapsedTime(time), ...data });
 }
 
 async function genericAccessCheck(name, url, done) {
@@ -105,7 +107,7 @@ async function genericAccessCheck(name, url, done) {
 const checks = [uploadCheck, websiteCheck, downloadCheck, skylinkSubdomainCheck, handshakeSubdomainCheck];
 
 if (process.env.ACCOUNTS_ENABLED) {
-  checks.push(accountHealthCheck);
+  checks.push(accountHealthCheck, accountWebsiteCheck);
 }
 
 module.exports = checks;

--- a/packages/health-check/src/checks/critical.js
+++ b/packages/health-check/src/checks/critical.js
@@ -57,7 +57,7 @@ async function handshakeSubdomainCheck(done) {
   return genericAccessCheck("hns_via_subdomain", url, done);
 }
 
-// handshakeSubdomainCheck returns the result of accessing account dashboard website
+// accountWebsiteCheck returns the result of accessing account dashboard website
 async function accountWebsiteCheck(done) {
   const url = `${process.env.SKYNET_DASHBOARD_URL}/auth/login`;
 


### PR DESCRIPTION
- added "website" check that makes sure main page responds ok and tests `siasky.net` ssl certificate
- added "skylink_via_subdomain" check that makes sure that people can access a skylink via subdomain and tests `*.siasky.net` ssl certificate
- added "hns_via_subdomain" check that makes sure that handshake domains work and tests `*.hns.siasky.net` ssl certificate
- added "account_website" check that makes sure that account dashboard website is accessible