### PR TITLE
use dnsmasq for aliasing siasky.net and all the subdomains

### DIFF
--- a/packages/health-check/Dockerfile
+++ b/packages/health-check/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:16.1.0-alpine
 
+RUN apk update && apk add dnsmasq
+
 WORKDIR /usr/app
 
 # schedule critical checks to run every 5 minutes (any failures will disable server)
@@ -16,9 +18,15 @@ COPY cli cli
 EXPOSE 3100
 ENV NODE_ENV production
 
-# command consists of 3 parts:
-# 1. starting crond
-# 2. aliasing siasky.net and account.siasky.net with current server ip so health checks 
-#    test portal end-to-end on prod domain (important for testing ssl certificates)
-# 3. running api service
-CMD [ "sh", "-c", "crond ; echo $(node src/whatismyip.js) siasky.net account.siasky.net >> /etc/hosts ; node --max-http-header-size=64000 src/index.js" ]
+# 1. alias siasky.net with current server ip to ommit load balancer
+# 2. prepend dnsmasq nameserver so it tries to resolve first
+# 3. start dnsmasq in the background
+# 4. start crond in the background
+# 5. start the health-check api service
+CMD [ "sh", "-c", \
+      "echo address=/siasky.net/$(node src/whatismyip.js) > /etc/dnsmasq.d/siasky.net.conf ; \
+       echo -e \"nameserver 127.0.0.1\n$(cat /etc/resolv.conf)\" > /etc/resolv.conf ; \
+       dnsmasq ; \
+       crond ; \
+       node --max-http-header-size=64000 src/index.js" \
+    ]


### PR DESCRIPTION
replace /etc/hosts solution with dnsmasq because /etc/hosts does not allow a regex or wildcards and we have numerous subdomains in health checks