### PR TITLE
use dc command instead of docker-compose directly

### DIFF
--- a/dc
+++ b/dc
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [ -f .env ]; then
+  export $(cat .env | sed 's/#.*//g' | xargs)
+fi
+
+for i in $(seq 1 ${#PORTAL_MODULES}); do
+  # accounts module - alias "a"
+  if [ ${PORTAL_MODULES:i-1:1} == "a" ]; then
+    COMPOSE_FILES+=" -f docker-compose.accounts.yml"
+  fi
+
+  # jaeger module - alias "j"
+  if [ ${PORTAL_MODULES:i-1:1} == "j" ]; then
+    COMPOSE_FILES+=" -f docker-compose.jaeger.yml"
+  fi
+done
+
+# override file if exists
+if [ -f docker-compose.override.yml ]; then
+  COMPOSE_FILES+=" -f docker-compose.override.yml"
+fi
+
+docker-compose $COMPOSE_FILES $@

--- a/dc
+++ b/dc
@@ -4,6 +4,9 @@ if [ -f .env ]; then
   export $(cat .env | sed 's/#.*//g' | xargs)
 fi
 
+# include base docker compose file
+COMPOSE_FILES="-f docker-compose.yml"
+
 for i in $(seq 1 ${#PORTAL_MODULES}); do
   # accounts module - alias "a"
   if [ ${PORTAL_MODULES:i-1:1} == "a" ]; then


### PR DESCRIPTION
Instead of using `docker-compose` and adding compose files manually, we can now use `./dc` command that already loads compose files based on `PORTAL_MODULES` variable in .env file. By default it loads only docker-compose.yml and docker-compose.override.yml if exists but you can set also "a" for accounts and "j" for jaeger. Example `PORTAL_MODULES=aj`