### PR TITLE
env variables are strings, fix conditions

### DIFF
--- a/packages/health-check/src/checks/critical.js
+++ b/packages/health-check/src/checks/critical.js
@@ -108,7 +108,7 @@ async function genericAccessCheck(name, url, done) {
 
 const checks = [uploadCheck, websiteCheck, downloadCheck, skylinkSubdomainCheck, handshakeSubdomainCheck];
 
-if (process.env.ACCOUNTS_ENABLED) {
+if (process.env.ACCOUNTS_ENABLED === "1") {
   checks.push(accountHealthCheck, accountWebsiteCheck);
 }
 

--- a/packages/health-check/src/index.js
+++ b/packages/health-check/src/index.js
@@ -4,7 +4,7 @@ if (!process.env.SKYNET_PORTAL_API) {
   throw new Error("You need to provide SKYNET_PORTAL_API environment variable");
 }
 
-if (process.env.ACCOUNTS_ENABLED && !process.env.SKYNET_DASHBOARD_URL) {
+if (process.env.ACCOUNTS_ENABLED === "1" && !process.env.SKYNET_DASHBOARD_URL) {
   throw new Error("You need to provide SKYNET_DASHBOARD_URL environment variable when accounts are enabled");
 }
 


### PR DESCRIPTION
all env variables are strings and we need to compare them accordingly - fixing issue where setting `ACCOUNTS_ENABLED=0` did not result in accounts being disabled