### PR TITLE
fix for osx and vars that contain spaces

### DIFF
--- a/dc
+++ b/dc
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -f .env ]; then
-  export $(cat .env | sed 's/#.*//g' | xargs)
+  OLD_IFS=$IFS; IFS=$'\n'; for x in `grep -v '^#.*' .env`; do export $x; done; IFS=$OLD_IFS
 fi
 
 # include base docker compose file
@@ -9,18 +9,18 @@ COMPOSE_FILES="-f docker-compose.yml"
 
 for i in $(seq 1 ${#PORTAL_MODULES}); do
   # accounts module - alias "a"
-  if [ ${PORTAL_MODULES:i-1:1} == "a" ]; then
+  if [[ ${PORTAL_MODULES:i-1:1} == "a" ]]; then
     COMPOSE_FILES+=" -f docker-compose.accounts.yml"
   fi
 
   # jaeger module - alias "j"
-  if [ ${PORTAL_MODULES:i-1:1} == "j" ]; then
+  if [[ ${PORTAL_MODULES:i-1:1} == "j" ]]; then
     COMPOSE_FILES+=" -f docker-compose.jaeger.yml"
   fi
 done
 
 # override file if exists
-if [ -f docker-compose.override.yml ]; then
+if [[ -f docker-compose.override.yml ]]; then
   COMPOSE_FILES+=" -f docker-compose.override.yml"
 fi
 


### PR DESCRIPTION
- fixed an issue where it would not work on osx
- changed a way of importing .env variables so they can contain spaces now