### PR TITLE
Clean up stats endpoint

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -119,33 +119,6 @@ server {
 	location /skynet/stats {
 		include /etc/nginx/conf.d/include/cors;
 
-		set $response_body ''; # we need a variable for full response body (not chuncked)
-
-		# modify the response to add numfiles and totalsize to account for node rotation
-		# example prevstats.lua: 'return { numfiles = 12345, totalsize = 123456789 }'
-		body_filter_by_lua_block {
-			local file_exists = io.open("/data/nginx/skynet/prevstats.lua")
-			if file_exists then
-				file_exists.close()
-
-				-- because response data is chunked, we need to concat ngx.arg[1] until
-				-- last chunk is received (when ngx.arg[2] is set to true)
-				ngx.var.response_body = ngx.var.response_body .. ngx.arg[1]
-
-				if ngx.arg[2] then
-					local json = require('cjson')
-					local prevstats = require('/data/nginx/skynet/prevstats')
-					local stats = json.decode(ngx.var.response_body)
-					stats.uploadstats.numfiles = stats.uploadstats.numfiles + prevstats.numfiles
-					stats.uploadstats.totalsize = stats.uploadstats.totalsize + prevstats.totalsize
-					ngx.arg[1] = json.encode(stats)
-				else
-					-- do not send any data in this chunk (wait for last chunk)
-					ngx.arg[1] = nil
-				end
-			end
-		}
-
 		proxy_cache skynet;
 		proxy_cache_valid any 1m; # cache stats for 1 minute
 		proxy_set_header User-Agent: Sia-Agent;


### PR DESCRIPTION
Clean up /stats endpoint since we don't need that code any more. It was needed when we had maintenance servers that hosted multiple siad nodes and stats were not reachable. Now every server is hosted on a separate machine.

closes #579