### PR TITLE
Request Timeouts

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -333,7 +333,12 @@ server {
 		limit_conn upload_conn_rl 1;
 
 		client_max_body_size 1000M; # make sure to limit the size of upload to a sane value
+
+		# increase request timeouts
 		proxy_read_timeout 600;
+		proxy_connect_timeout 600;
+		proxy_send_timeout 600;
+
 		proxy_request_buffering off; # stream uploaded files through the proxy as it comes in
 		proxy_set_header Expect $http_expect;
 		proxy_set_header User-Agent: Sia-Agent;
@@ -391,7 +396,12 @@ server {
 		include /etc/nginx/conf.d/include/cors;
 
 		client_max_body_size 50M; # tus chunks size is 40M + leaving 10M of breathing room
+
+		# increase request timeouts
 		proxy_read_timeout 600;
+		proxy_connect_timeout 600;
+		proxy_send_timeout 600;
+
 		proxy_request_buffering off; # stream uploaded files through the proxy as it comes in
 		proxy_set_header Expect $http_expect;
 

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -336,7 +336,6 @@ server {
 
 		# increase request timeouts
 		proxy_read_timeout 600;
-		proxy_connect_timeout 600;
 		proxy_send_timeout 600;
 
 		proxy_request_buffering off; # stream uploaded files through the proxy as it comes in
@@ -399,7 +398,6 @@ server {
 
 		# increase request timeouts
 		proxy_read_timeout 600;
-		proxy_connect_timeout 600;
 		proxy_send_timeout 600;
 
 		proxy_request_buffering off; # stream uploaded files through the proxy as it comes in


### PR DESCRIPTION
This PR increases the request timeouts from their defaults up to `600s`. We were setting the `proxy_read_timeout` but I believe we also need to set `proxy_send_timeout`, at least for uploads. This was tested and verified on `siasky.xyz` and `eu-ger-1` (still live) and should alleviate our upload issues at least a little.