### PR TITLE
do not exit on error from /resolve

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -394,9 +394,6 @@ server {
 					local json = require('cjson')
 					local resolve = json.decode(res.body)
 					ngx.var.skylink_v1 = resolve.skylink
-				else
-					ngx.say(res.body)
-					ngx.exit(res.status)
 				end
 			end
 


### PR DESCRIPTION
temporary solution - do not exit on error response from /resolve endpoint, just let the actual skylink endpoint respond with the error - it's not going to get cached anyway because we don't cache errors

temporary because it introduces one more read and we could have just exit early