### PR TITLE
add skynet-skylink header to tus final response

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -334,6 +334,17 @@ server {
 
 		# rewrite tus headers to use correct uri
 		proxy_redirect https://siad/ https://$domain.$tld/;
+
+		# extract skylink from base64 encoded upload metadata and assign to a proper header
+		header_filter_by_lua_block {
+			if ngx.header["Upload-Metadata"] then
+				local encodedSkylink = string.match(ngx.header["Upload-Metadata"], "Skylink ([^,?]+)")
+
+				if encodedSkylink then
+					ngx.header["Skynet-Skylink"] = ngx.decode_base64(encodedSkylink)
+				end
+			end
+		}
 	}
 
 	location /skynet/pin {

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -42,7 +42,7 @@ http {
         '"$http_user_agent" $upstream_response_time '
         '$upstream_bytes_sent $upstream_bytes_received '
         '"$upstream_http_content_type" "$upstream_cache_status" '
-        '"$portal_domain" "$upstream_http_skynet_skylink" '
+        '"$portal_domain" "$sent_http_skynet_skylink" '
         '$upstream_connect_time $upstream_header_time '
         '$request_time "$hns_domain"';
 


### PR DESCRIPTION
- added Skynet-Skylink header to a final successful /skynet/tus response by parsing Upload-Metadata header
   - Upload-Metadata entries are comma separated, keys are separated by space, value is base64 encoded 
   - example Upload-Metadata `Skylink QUFBVHZCQW1SZHhCZDVWVThpckZjSE9HbDJ1QkJuRjJQZ2ZNRm55VUhkQXlXQQ==,filename VGVycmEgU3RhdGlvbi0xLjEuMCAoMSkuZG1n,filetype YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt`
- changed `$upstream_http_skynet_skylink` to `$sent_http_skynet_skylink` so it picks up the Skynet-Skylink metadata we add that is not a part of upstream response