### PR TITLE
Support accounts on tus uploads

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -319,6 +319,7 @@ server {
 	# endpoing implementing resumable file uploads open protocol https://tus.io
 	location /skynet/tus {
 		include /etc/nginx/conf.d/include/cors;
+		include /etc/nginx/conf.d/include/track-upload;
 
 		client_max_body_size 50M; # tus chunks size is 40M + leaving 10M of breathing room
 


### PR DESCRIPTION
adds tracking uploads support to /skynet/tus endpoint

<img width="1164" alt="Screenshot 2021-06-09 at 15 23 31" src="https://user-images.githubusercontent.com/3755029/121362818-b1014700-c936-11eb-9663-85df8db7eb08.png">
