### PR TITLE
enable jaeger by default if docker-compose.jaeger.yml is included

### DIFF
--- a/docker-compose.jaeger.yml
+++ b/docker-compose.jaeger.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   sia:
     environment:
-      - JAEGER_DISABLED=${JAEGER_DISABLED:-true} # Enable/Disable tracing
+      - JAEGER_DISABLED=${JAEGER_DISABLED:-false} # Enable/Disable tracing
       - JAEGER_SERVICE_NAME=${PORTAL_NAME:-Skyd} # change to e.g. eu-ger-1
       # Configuration
       # See https://github.com/jaegertracing/jaeger-client-go#environment-variables


### PR DESCRIPTION
- we're only including docker-compose.jaeger.yml if we want to enable jaeger, no need to disable it then