### PR TITLE
Fix skylink v2 redirect

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -440,7 +440,7 @@ server {
 
 		proxy_read_timeout 600;
 		proxy_set_header User-Agent: Sia-Agent;
-		# proxy this call to siad /skynet/skylink/ endpoint (make sure the ip is correct)
+		proxy_redirect $skylink_v1 $skylink_v2
 		proxy_pass http://siad/skynet/skylink/$skylink_v1$path$is_args$args;
 	}
 

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -409,12 +409,16 @@ server {
 		set $skylink $2;
 		set $path $3;
 
-		# v2 support
+		# $skylink_v1 and $skylink_v2 variables default to the same value but in case the requested skylink was:
+		# a) skylink v1 - it wouldn't matter, no additional logic is executed
+		# b) skylink v2 - in a lua block below we will resolve the skylink v2 into skylink v1 and update 
+		#      $skylink_v1 variable so then the proxy request to skyd can be cached in nginx (proxy_cache_key 
+		#      in proxy-cache-downloads includes $skylink_v1 as a part of the cache key)
 		set $skylink_v1 $skylink;
 		set $skylink_v2 $skylink;
 
 		access_by_lua_block {
-			-- disable cache if this is skylink v2
+			-- detect whether requested skylink is v2
 			local isBase32v2 = string.len(ngx.var.skylink) == 55 and string.sub(ngx.var.skylink, 0, 2) == "04"
 			local isBase64v2 = string.len(ngx.var.skylink) == 46 and string.sub(ngx.var.skylink, 0, 2) == "AQ"
 			
@@ -440,6 +444,10 @@ server {
 
 		proxy_read_timeout 600;
 		proxy_set_header User-Agent: Sia-Agent;
+		
+		# in case the requested skylink was v2 and we already resolved it to skylink v1, we're going to pass resolved 
+		# skylink v1 to skyd to save that extra skylink v2 lookup in skyd but in turn, in case skyd returns a redirect 
+		# we need to rewrite the skylink v1 to skylink v2 in the location header with proxy_redirect
 		proxy_redirect $skylink_v1 $skylink_v2;
 		proxy_pass http://siad/skynet/skylink/$skylink_v1$path$is_args$args;
 	}

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -440,7 +440,7 @@ server {
 
 		proxy_read_timeout 600;
 		proxy_set_header User-Agent: Sia-Agent;
-		proxy_redirect $skylink_v1 $skylink_v2
+		proxy_redirect $skylink_v1 $skylink_v2;
 		proxy_pass http://siad/skynet/skylink/$skylink_v1$path$is_args$args;
 	}
 


### PR DESCRIPTION
### problem

When accessing a skylink v2 skapp without the trailing slash, we would get redirected to a link with trailing slash BUT to underlying skylink v1 and not the skylink v2 that we requested.


### solution

replace skylink v1 with skylink v2 in skyd location header response if we were fetching skylink v1 for v2 request

### verification

verify with `AQBUUNFGvF261JuvCZjEBQILdfB1UqVmaWuLS8MKPv82Yw` skylink for example (currently not deployed anywhere - ping me for tests)