### PR TITLE
use webhook instead of discrod bot to send messages

### DIFF
--- a/setup-scripts/README.md
+++ b/setup-scripts/README.md
@@ -92,7 +92,9 @@ At this point we have almost everything running, we just need to set up your wal
    - `AWS_ACCESS_KEY_ID` (optional) if using route53 as a dns loadbalancer
    - `AWS_SECRET_ACCESS_KEY` (optional) if using route53 as a dns loadbalancer
    - `PORTAL_NAME` a string representing name of your portal e.g. `siasky.xyz` or `my skynet portal`
-   - `DISCORD_BOT_TOKEN` (optional) if you're using Discord notifications for health checks and such
+   - `DISCORD_WEBHOOK_URL` (required if using Discord notifications) discord webhook url (generate from discord app)
+   - `DISCORD_MENTION_USER_ID` (optional) add `/cc @user` mention to important messages from webhook (has to be id not user name)
+   - `DISCORD_MENTION_ROLE_ID` (optional) add `/cc @role` mention to important messages from webhook (has to be id not role name)
    - `SKYNET_DB_USER` (optional) if using `accounts` this is the MongoDB username
    - `SKYNET_DB_PASS` (optional) if using `accounts` this is the MongoDB password
    - `SKYNET_DB_HOST` (optional) if using `accounts` this is the MongoDB address or container name

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -56,7 +56,7 @@ async def block_skylinks_from_airtable():
                 + ": "
                 + response_text
             )
-            return print(message) or await send_msg(message, force_notify=False)
+            return print(message) or await send_msg(message, force_notify=True)
 
         data = response.json()
 

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -3,13 +3,20 @@
 import traceback, os, re, asyncio, requests, json, discord
 from bot_utils import setup, send_msg
 
-bot_token = setup()
-client = discord.Client()
+setup()
 
 AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
 AIRTABLE_BASE = os.getenv("AIRTABLE_BASE", "app89plJvA9EqTJEc")
 AIRTABLE_TABLE = os.getenv("AIRTABLE_TABLE", "Table%201")
 AIRTABLE_FIELD = os.getenv("AIRTABLE_FIELD", "Link")
+
+
+async def run_checks():
+    try:
+        await block_skylinks_from_airtable()
+    except:  # catch all exceptions
+        trace = traceback.format_exc()
+        await send_msg("```\n{}\n```".format(trace), force_notify=True)
 
 
 def exec(command):
@@ -22,41 +29,72 @@ async def block_skylinks_from_airtable():
     skylinks = []
     offset = None
     while len(skylinks) == 0 or offset:
-        print("Requesting a batch of records from Airtable with " + (offset if offset else "empty") + " offset")
-        query = "&".join(["fields%5B%5D=" + AIRTABLE_FIELD, ("offset=" + offset) if offset else ""])
+        print(
+            "Requesting a batch of records from Airtable with "
+            + (offset if offset else "empty")
+            + " offset"
+        )
+        query = "&".join(
+            ["fields%5B%5D=" + AIRTABLE_FIELD, ("offset=" + offset) if offset else ""]
+        )
         response = requests.get(
-            "https://api.airtable.com/v0/" + AIRTABLE_BASE + "/" + AIRTABLE_TABLE + "?" + query,
+            "https://api.airtable.com/v0/"
+            + AIRTABLE_BASE
+            + "/"
+            + AIRTABLE_TABLE
+            + "?"
+            + query,
             headers=headers,
         )
 
         if response.status_code != 200:
             status_code = str(response.status_code)
             response_text = response.text or "empty response"
-            message = "Airtable blocklist integration responded with code " + status_code + ": " + response_text
-            return print(message) or await send_msg(client, message, force_notify=False)
+            message = (
+                "Airtable blocklist integration responded with code "
+                + status_code
+                + ": "
+                + response_text
+            )
+            return print(message) or await send_msg(message, force_notify=False)
 
         data = response.json()
 
         if len(data["records"]) == 0:
-            return print("Airtable returned 0 records - make sure your configuration is correct")
+            return print(
+                "Airtable returned 0 records - make sure your configuration is correct"
+            )
 
-        skylinks = skylinks + [entry["fields"].get(AIRTABLE_FIELD, "") for entry in data["records"]]
-        skylinks = [skylink for skylink in skylinks if skylink] # filter empty skylinks, most likely empty rows
+        skylinks = skylinks + [
+            entry["fields"].get(AIRTABLE_FIELD, "") for entry in data["records"]
+        ]
+        skylinks = [
+            skylink for skylink in skylinks if skylink
+        ]  # filter empty skylinks, most likely empty rows
 
         offset = data.get("offset")
 
     print("Airtable returned total " + str(len(skylinks)) + " skylinks to block")
 
     skylinks_returned = skylinks
-    skylinks = [skylink for skylink in skylinks if re.search("^[a-zA-Z0-9_-]{46}$", skylink)]
+    skylinks = [
+        skylink for skylink in skylinks if re.search("^[a-zA-Z0-9_-]{46}$", skylink)
+    ]
 
     if len(skylinks_returned) != len(skylinks):
-        invalid_skylinks = [str(skylink) for skylink in list(set(skylinks_returned) - set(skylinks))]
-        message = str(len(invalid_skylinks)) + " of the skylinks returned from Airtable are not valid"
-        print(message) or await send_msg(client, message, file=("\n".join(invalid_skylinks)))
+        invalid_skylinks = [
+            str(skylink) for skylink in list(set(skylinks_returned) - set(skylinks))
+        ]
+        message = (
+            str(len(invalid_skylinks))
+            + " of the skylinks returned from Airtable are not valid"
+        )
+        print(message) or await send_msg(message, file=("\n".join(invalid_skylinks)))
 
     apipassword = exec("docker exec sia cat /sia-data/apipassword")
-    ipaddress = exec("docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' sia")
+    ipaddress = exec(
+        "docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' sia"
+    )
 
     print("Sending blocklist request to siad")
     response = requests.post(
@@ -71,43 +109,39 @@ async def block_skylinks_from_airtable():
     else:
         status_code = str(response.status_code)
         response_text = response.text or "empty response"
-        message = "Siad blocklist endpoint responded with code " + status_code + ": " + response_text
-        return print(message) or await send_msg(client, message, force_notify=False)
+        message = (
+            "Siad blocklist endpoint responded with code "
+            + status_code
+            + ": "
+            + response_text
+        )
+        return print(message) or await send_msg(message, force_notify=False)
 
     print("Searching nginx cache for blocked files")
     cached_files_count = 0
     for i in range(0, len(skylinks), 1000):
         cached_files_command = (
             "/usr/bin/find /data/nginx/cache/ -type f | /usr/bin/xargs --no-run-if-empty -n1000 /bin/grep -Els '^KEY: .*("
-            + "|".join(skylinks[i:i+1000])
+            + "|".join(skylinks[i : i + 1000])
             + ")'"
         )
-        cached_files_count += int(exec('docker exec -it nginx bash -c "' + cached_files_command + ' | wc -l"') or 0)
+        cached_files_count += int(
+            exec('docker exec -it nginx bash -c "' + cached_files_command + ' | wc -l"')
+            or 0
+        )
 
     if cached_files_count == 0:
         return print("No nginx cached files matching blocked skylinks were found")
 
     exec('docker exec -it nginx bash -c "' + cached_files_command + ' | xargs rm"')
-    message = "Purged " + str(cached_files_count) + " blocklisted files from nginx cache"
-    return print(message) or await send_msg(client, message)
+    message = (
+        "Purged " + str(cached_files_count) + " blocklisted files from nginx cache"
+    )
+    return print(message) or await send_msg(message)
 
 
-async def exit_after(delay):
-    await asyncio.sleep(delay)
-    os._exit(0)
-
-
-@client.event
-async def on_ready():
-    try:
-        await block_skylinks_from_airtable()
-    except:  # catch all exceptions
-        message = "```\n{}\n```".format(traceback.format_exc())
-        await send_msg(client, message, force_notify=False)
-    asyncio.create_task(exit_after(3))
-
-
-client.run(bot_token)
+loop = asyncio.get_event_loop()
+loop.run_until_complete(run_checks())
 
 # --- BASH EQUIVALENT
 # skylinks=$(curl "https://api.airtable.com/v0/${AIRTABLE_BASE}/${AIRTABLE_TABLE}?fields%5B%5D=${AIRTABLE_FIELD}" -H "Authorization: Bearer ${AIRTABLE_KEY}" | python3 -c "import sys, json; print('[\"' + '\",\"'.join([entry['fields']['Link'] for entry in json.load(sys.stdin)['records']]) + '\"]')")

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -39,7 +39,7 @@ async def block_skylinks_from_airtable():
             status_code = str(response.status_code)
             response_text = response.text or "empty response"
             message = "Airtable blocklist integration responded with code " + status_code + ": " + response_text
-            return print(message) or await send_msg(message, force_notify=False)
+            return await send_msg(message, force_notify=False)
 
         data = response.json()
 
@@ -59,7 +59,7 @@ async def block_skylinks_from_airtable():
     if len(skylinks_returned) != len(skylinks):
         invalid_skylinks = [str(skylink) for skylink in list(set(skylinks_returned) - set(skylinks))]
         message = str(len(invalid_skylinks)) + " of the skylinks returned from Airtable are not valid"
-        print(message) or await send_msg(message, file=("\n".join(invalid_skylinks)))
+        await send_msg(message, file=("\n".join(invalid_skylinks)))
 
     apipassword = exec("docker exec sia cat /sia-data/apipassword")
     ipaddress = exec("docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' sia")
@@ -78,7 +78,7 @@ async def block_skylinks_from_airtable():
         status_code = str(response.status_code)
         response_text = response.text or "empty response"
         message = "Siad blocklist endpoint responded with code " + status_code + ": " + response_text
-        return print(message) or await send_msg(message, force_notify=False)
+        return await send_msg(message, force_notify=False)
 
     print("Searching nginx cache for blocked files")
     cached_files_count = 0
@@ -95,7 +95,7 @@ async def block_skylinks_from_airtable():
 
     exec('docker exec -it nginx bash -c "' + cached_files_command + ' | xargs rm"')
     message = "Purged " + str(cached_files_count) + " blocklisted files from nginx cache"
-    return print(message) or await send_msg(message)
+    return await send_msg(message)
 
 
 loop = asyncio.get_event_loop()

--- a/setup-scripts/bot_utils.py
+++ b/setup-scripts/bot_utils.py
@@ -60,7 +60,7 @@ def setup():
 async def send_msg(msg, force_notify=False, file=None):
     webhook_url = os.getenv("DISCORD_WEBHOOK_URL")
     webhook_mention_user = os.getenv("DISCORD_MENTION_USER")
-    webhook_mention_role = os.getenv("DISCORD_MENTION_ROLE", "skynet-prod")
+    webhook_mention_role = os.getenv("DISCORD_MENTION_ROLE", "699294748220850346")
     webhook = DiscordWebhook(url=webhook_url, rate_limit_retry=True)
 
     # Add the portal name.
@@ -82,11 +82,11 @@ async def send_msg(msg, force_notify=False, file=None):
             webhook.add_file(file=file.read(), filename=filename)
 
     if force_notify and (webhook_mention_user or webhook_mention_role):
-        # webhook.allowed_mentions = {
-        #     "parse": ["users", "roles"],
-        #     "users": [webhook_mention_user],
-        #     "roles": [webhook_mention_role],
-        # }
+        webhook.allowed_mentions = {
+            "parse": ["users", "roles"],
+            "users": [webhook_mention_user],
+            "roles": [webhook_mention_role],
+        }
         msg = "{} /cc".format(msg)  # separate message from mentions
         if webhook_mention_role:
             msg = "{} <@&{}>".format(msg, webhook_mention_role)

--- a/setup-scripts/bot_utils.py
+++ b/setup-scripts/bot_utils.py
@@ -57,10 +57,10 @@ def setup():
 
 
 # send_msg sends the msg to the specified discord channel. If force_notify is set to true it adds "@here".
-async def send_msg(msg, force_notify=False, file="teeeeeest"):
+async def send_msg(msg, force_notify=False, file=None):
     webhook_url = os.getenv("DISCORD_WEBHOOK_URL")
-    webhook_mention_user = os.getenv("DISCORD_MENTION_USER")
-    webhook_mention_role = os.getenv("DISCORD_MENTION_ROLE", "699294748220850346")
+    webhook_mention_user_id = os.getenv("DISCORD_MENTION_USER_ID")
+    webhook_mention_role_id = os.getenv("DISCORD_MENTION_ROLE_ID")
     webhook = DiscordWebhook(url=webhook_url, rate_limit_retry=True)
 
     # Add the portal name.
@@ -77,19 +77,18 @@ async def send_msg(msg, force_notify=False, file="teeeeeest"):
         if skylink:
             msg = "{} {}".format(msg, skylink)  # append skylink to message
         else:
-            file = io.BytesIO(file.encode())
-            webhook.add_file(file=file, filename=filename)
+            webhook.add_file(file=io.BytesIO(file.encode()), filename=filename)
 
-    if force_notify and (webhook_mention_user or webhook_mention_role):
+    if force_notify and (webhook_mention_user_id or webhook_mention_role_id):
         webhook.allowed_mentions = {
-            "users": [webhook_mention_user],
-            "roles": [webhook_mention_role],
+            "users": [webhook_mention_user_id],
+            "roles": [webhook_mention_role_id],
         }
         msg = "{} /cc".format(msg)  # separate message from mentions
-        if webhook_mention_role:
-            msg = "{} <@&{}>".format(msg, webhook_mention_role)
-        if webhook_mention_user:
-            msg = "{} <@{}>".format(msg, webhook_mention_user)
+        if webhook_mention_role_id:
+            msg = "{} <@&{}>".format(msg, webhook_mention_role_id)
+        if webhook_mention_user_id:
+            msg = "{} <@{}>".format(msg, webhook_mention_user_id)
 
     webhook.content = msg
     webhook.execute()

--- a/setup-scripts/bot_utils.py
+++ b/setup-scripts/bot_utils.py
@@ -82,11 +82,11 @@ async def send_msg(msg, force_notify=False, file=None):
             webhook.add_file(file=file.read(), filename=filename)
 
     if force_notify and (webhook_mention_user or webhook_mention_role):
-        webhook.allowed_mentions = {
-            "parse": ["users", "roles"],
-            "users": [webhook_mention_user],
-            "roles": [webhook_mention_role],
-        }
+        # webhook.allowed_mentions = {
+        #     "parse": ["users", "roles"],
+        #     "users": [webhook_mention_user],
+        #     "roles": [webhook_mention_role],
+        # }
         msg = "{} /cc".format(msg)  # separate message from mentions
         if webhook_mention_role:
             msg = "{} <@&{}>".format(msg, webhook_mention_role)

--- a/setup-scripts/bot_utils.py
+++ b/setup-scripts/bot_utils.py
@@ -76,10 +76,9 @@ async def send_msg(msg, force_notify=False, file="teeeeeest"):
         skylink = None # upload_to_skynet(file, filename, content_type=content_type)
         if skylink:
             msg = "{} {}".format(msg, skylink)  # append skylink to message
-            file = None  # clean file reference, we're using a skylink
         else:
-            # io.BytesIO(file.encode())
-            webhook.add_file(file=file.read(), filename=filename)
+            file = io.BytesIO(file.encode())
+            webhook.add_file(file=file, filename=filename)
 
     if force_notify and (webhook_mention_user or webhook_mention_role):
         webhook.allowed_mentions = {

--- a/setup-scripts/bot_utils.py
+++ b/setup-scripts/bot_utils.py
@@ -56,7 +56,7 @@ def setup():
 
 
 # send_msg sends the msg to the specified discord channel. If force_notify is set to true it adds "@here".
-async def send_msg(client, msg, force_notify=False, file=None):
+async def send_msg(msg, force_notify=False, file=None):
     webhook_url = os.getenv("DISCORD_WEBHOOK_URL")
     webhook_notify_role = os.getenv("DISCORD_BOT_NOTIFY_ROLE", "skynet-prod")
     webhook = DiscordWebhook(url=webhook_url, rate_limit_retry=True)

--- a/setup-scripts/bot_utils.py
+++ b/setup-scripts/bot_utils.py
@@ -83,7 +83,6 @@ async def send_msg(msg, force_notify=False, file=None):
 
     if force_notify and (webhook_mention_user or webhook_mention_role):
         webhook.allowed_mentions = {
-            "parse": ["users", "roles"],
             "users": [webhook_mention_user],
             "roles": [webhook_mention_role],
         }

--- a/setup-scripts/bot_utils.py
+++ b/setup-scripts/bot_utils.py
@@ -73,7 +73,7 @@ async def send_msg(msg, force_notify=False, file="teeeeeest"):
         filename = "{}-{}.{}".format(
             CONTAINER_NAME, datetime.utcnow().strftime("%Y-%m-%d-%H:%M:%S"), ext
         )
-        skylink = None # upload_to_skynet(file, filename, content_type=content_type)
+        skylink = upload_to_skynet(file, filename, content_type=content_type)
         if skylink:
             msg = "{} {}".format(msg, skylink)  # append skylink to message
         else:

--- a/setup-scripts/bot_utils.py
+++ b/setup-scripts/bot_utils.py
@@ -57,7 +57,7 @@ def setup():
 
 
 # send_msg sends the msg to the specified discord channel. If force_notify is set to true it adds "@here".
-async def send_msg(msg, force_notify=False, file=None):
+async def send_msg(msg, force_notify=False, file="teeeeeest"):
     webhook_url = os.getenv("DISCORD_WEBHOOK_URL")
     webhook_mention_user = os.getenv("DISCORD_MENTION_USER")
     webhook_mention_role = os.getenv("DISCORD_MENTION_ROLE", "699294748220850346")
@@ -73,7 +73,7 @@ async def send_msg(msg, force_notify=False, file=None):
         filename = "{}-{}.{}".format(
             CONTAINER_NAME, datetime.utcnow().strftime("%Y-%m-%d-%H:%M:%S"), ext
         )
-        skylink = upload_to_skynet(file, filename, content_type=content_type)
+        skylink = None # upload_to_skynet(file, filename, content_type=content_type)
         if skylink:
             msg = "{} {}".format(msg, skylink)  # append skylink to message
             file = None  # clean file reference, we're using a skylink

--- a/setup-scripts/bot_utils.py
+++ b/setup-scripts/bot_utils.py
@@ -22,11 +22,6 @@ if len(sys.argv) > 2:
 # sc_precision is the number of hastings per siacoin
 sc_precision = 10 ** 24
 
-# sia deamon local ip address with port
-api_endpoint = "http://{}:{}".format(
-    get_docker_container_ip(CONTAINER_NAME), os.getenv("API_PORT", "9980")
-)
-
 # Environment variable globals
 setup_done = False
 
@@ -40,6 +35,10 @@ def get_docker_container_ip(container_name):
     output = subprocess.check_output(docker_cmd, shell=True).decode("utf-8")
     return ip_regex.findall(output)[0]
 
+# sia deamon local ip address with port
+api_endpoint = "http://{}:{}".format(
+    get_docker_container_ip(CONTAINER_NAME), os.getenv("API_PORT", "9980")
+)
 
 # find siad api password by getting it out of the docker container
 def get_api_password():

--- a/setup-scripts/health-checker.py
+++ b/setup-scripts/health-checker.py
@@ -38,20 +38,7 @@ GB = 1 << 30  # 1 GiB in bytes
 FREE_DISK_SPACE_THRESHOLD = 50 * GB
 FREE_DISK_SPACE_THRESHOLD_CRITICAL = 20 * GB
 
-bot_token = setup()
-client = discord.Client()
-
-
-# exit_after kills the script if it hasn't exited on its own after `delay` seconds
-async def exit_after(delay):
-    await asyncio.sleep(delay)
-    os._exit(0)
-
-
-@client.event
-async def on_ready():
-    await run_checks()
-    asyncio.create_task(exit_after(3))
+setup()
 
 
 async def run_checks():
@@ -66,7 +53,6 @@ async def run_checks():
         trace = traceback.format_exc()
         print("[DEBUG] run_checks() failed.")
         await send_msg(
-            client,
             "Failed to run the portal health checks!",
             file=trace,
             force_notify=True,
@@ -84,7 +70,7 @@ async def check_load_average():
     load_av = re.match(pattern, uptime_string).group(1)
     if float(load_av) > 10:
         message = "High system load detected in uptime output: {}".format(uptime_string)
-        await send_msg(client, message, force_notify=True)
+        await send_msg(message, force_notify=True)
 
 
 # check_disk checks the amount of free space on the /home partition and issues
@@ -109,7 +95,7 @@ async def check_disk():
             break
     if vol == "":
         message = "Failed to check free disk space! Didn't find a suitable mount point to check."
-        return await send_msg(client, message, file=df)
+        return await send_msg(message, file=df)
 
     # if we've reached a critical free disk space threshold we need to send proper notice
     # and shut down sia container so it doesn't get corrupted
@@ -125,13 +111,13 @@ async def check_disk():
             os.popen("docker exec health-check cli/disable")
             time.sleep(300)  # wait 5 minutes to propagate dns changes
             os.popen("docker stop sia")  # stop sia container
-        return await send_msg(client, message, force_notify=True)
+        return await send_msg(message, force_notify=True)
 
     # if we're reached a free disk space threshold we need to send proper notice
     if int(volumes[vol]) < FREE_DISK_SPACE_THRESHOLD:
         free_space_gb = "{:.2f}".format(int(volumes[vol]) / GB)
         message = "WARNING! Low disk space: {}GiB".format(free_space_gb)
-        return await send_msg(client, message, force_notify=True)
+        return await send_msg(message, force_notify=True)
 
 
 # check_health checks /health-check endpoint and reports recent issues
@@ -142,7 +128,7 @@ async def check_health():
         endpoint = "http://{}:{}".format(get_docker_container_ip("health-check"), 3100)
     except:
         message = "Could not get health check service endpoint api!"
-        return await send_msg(client, message, force_notify=True)
+        return await send_msg(message, force_notify=True)
 
     try:
         res = requests.get(endpoint + "/health-check", verify=False)
@@ -158,10 +144,12 @@ async def check_health():
     except:
         message = traceback.format_exc()
         message += "\n" + "Request url: " + res.url if res.url else "-"
-        message += "\n" + "Status code: " + str(res.status_code) if res.status_code else "-"
+        message += (
+            "\n" + "Status code: " + str(res.status_code) if res.status_code else "-"
+        )
         message += "\n" + "Response body: " + res.text if res.text else "-"
         return await send_msg(
-            client, "Failed to run health checks!", file=message, force_notify=True
+            "Failed to run health checks!", file=message, force_notify=True
         )
 
     critical_checks_total = 0
@@ -241,7 +229,7 @@ async def check_health():
         or datetime.utcnow().hour == 1
     ):
         return await send_msg(
-            client, message, file=failed_records_file, force_notify=force_notify
+            message, file=failed_records_file, force_notify=force_notify
         )
 
 
@@ -340,7 +328,7 @@ async def check_alerts():
     # on 1 AM
     if force_notify or datetime.utcnow().hour == 1:
         return await send_msg(
-            client, message, file=siac_alert_output, force_notify=force_notify
+            message, file=siac_alert_output, force_notify=force_notify
         )
 
 
@@ -383,7 +371,8 @@ async def check_portal_size():
 
     # send a message if we force notification, or just once daily (heartbeat) on 1 AM
     if force_notify or datetime.utcnow().hour == 1:
-        return await send_msg(client, message, force_notify=force_notify)
+        return await send_msg(message, force_notify=force_notify)
 
 
-client.run(bot_token)
+loop = asyncio.get_event_loop()
+loop.run_until_complete(run_checks())

--- a/setup-scripts/log-checker.py
+++ b/setup-scripts/log-checker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import discord, sys, traceback, io, os, asyncio
+import sys, traceback, io, os, asyncio
 from bot_utils import setup, send_msg, upload_to_skynet
 from subprocess import Popen, PIPE
 
@@ -31,20 +31,7 @@ if len(sys.argv) > 3:
 # a lower limit in order to leave some space for additional message text.
 DISCORD_MAX_MESSAGE_LENGTH = 1900
 
-bot_token = setup()
-client = discord.Client()
-
-
-# exit_after kills the script if it hasn't exited on its own after `delay` seconds
-async def exit_after(delay):
-    await asyncio.sleep(delay)
-    os._exit(0)
-
-
-@client.event
-async def on_ready():
-    await run_checks()
-    asyncio.create_task(exit_after(3))
+setup()
 
 
 async def run_checks():
@@ -53,7 +40,7 @@ async def run_checks():
         await check_docker_logs()
     except:  # catch all exceptions
         trace = traceback.format_exc()
-        await send_msg(client, "```\n{}\n```".format(trace), force_notify=False)
+        await send_msg("```\n{}\n```".format(trace), force_notify=False)
 
 
 # check_docker_logs checks the docker logs by filtering on the docker image name
@@ -84,13 +71,12 @@ async def check_docker_logs():
             pos = std_err.find("\n", -one_mb)
             std_err = std_err[pos + 1 :]
             return await send_msg(
-                client, "Error(s) found in log!", file=std_err, force_notify=True
+                "Error(s) found in log!", file=std_err, force_notify=True
             )
 
     # If there are any critical or severe errors. upload the whole log file.
     if "Critical" in std_out or "Severe" in std_out or "panic" in std_out:
         return await send_msg(
-            client,
             "Critical or Severe error found in log!",
             file=std_out,
             force_notify=True,
@@ -98,9 +84,9 @@ async def check_docker_logs():
 
     # No critical or severe errors, return a heartbeat type message
     return await send_msg(
-        client,
         "No critical or severe warnings in log since {} hours".format(CHECK_HOURS),
     )
 
 
-client.run(bot_token)
+loop = asyncio.get_event_loop()
+loop.run_until_complete(run_checks())

--- a/setup-scripts/setup-docker-services.sh
+++ b/setup-scripts/setup-docker-services.sh
@@ -32,7 +32,9 @@ docker-compose --version # sanity check
 # * AWS_SECRET_ACCESS_KEY - (optional) if using route53 as a dns loadbalancer
 # * API_PORT - (optional) the port on which siad is listening, defaults to 9980
 # * PORTAL_NAME - a string representing name of your portal e.g. `siasky.xyz` or `my skynet portal` (internal use only)
-# * DISCORD_BOT_TOKEN - (optional) only required if you're using the discord notifications integration
+# * DISCORD_WEBHOOK_URL - (required if using Discord notifications) discord webhook url (generate from discord app)
+# * DISCORD_MENTION_USER_ID - (optional) add `/cc @user` mention to important messages from webhook (has to be id not user name)
+# * DISCORD_MENTION_ROLE_ID - (optional) add `/cc @role` mention to important messages from webhook (has to be id not role name)
 # * SKYNET_DB_USER - (optional) if using `accounts` this is the MongoDB username
 # * SKYNET_DB_PASS - (optional) if using `accounts` this is the MongoDB password
 # * SKYNET_DB_HOST - (optional) if using `accounts` this is the MongoDB address or container name
@@ -44,7 +46,7 @@ docker-compose --version # sanity check
 # * CR_CLUSTER_NODES - (optional) if using `accounts` the list of servers (with ports) which make up your CockroachDB cluster, e.g. `helsinki.siasky.net:26257,germany.siasky.net:26257,us-east.siasky.net:26257`
 if ! [ -f /home/user/skynet-webportal/.env ]; then
     HSD_API_KEY=$(openssl rand -base64 32) # generate safe random key for handshake
-    printf "SSL_CERTIFICATE_STRING=siasky.net, *.siasky.net, *.hns.siasky.net\nSKYNET_PORTAL_API=https://siasky.net\nSKYNET_SERVER_API=https://eu-dc-1.siasky.net\nSKYNET_DASHBOARD_URL=https://account.example.com\nEMAIL_ADDRESS=email@example.com\nSIA_WALLET_PASSWORD=\nHSD_API_KEY=${HSD_API_KEY}\nCLOUDFLARE_AUTH_TOKEN=\nAWS_ACCESS_KEY_ID=\nAWS_SECRET_ACCESS_KEY=\nPORTAL_NAME=\nDISCORD_BOT_TOKEN=\n" > /home/user/skynet-webportal/.env
+    printf "SSL_CERTIFICATE_STRING=siasky.net, *.siasky.net, *.hns.siasky.net\nSKYNET_PORTAL_API=https://siasky.net\nSKYNET_SERVER_API=https://eu-dc-1.siasky.net\nSKYNET_DASHBOARD_URL=https://account.example.com\nEMAIL_ADDRESS=email@example.com\nSIA_WALLET_PASSWORD=\nHSD_API_KEY=${HSD_API_KEY}\nCLOUDFLARE_AUTH_TOKEN=\nAWS_ACCESS_KEY_ID=\nAWS_SECRET_ACCESS_KEY=\nPORTAL_NAME=\DISCORD_WEBHOOK_URL=\nDISCORD_MENTION_USER_ID=\nDISCORD_MENTION_ROLE_ID=\n" > /home/user/skynet-webportal/.env
 fi
 
 # Start docker container with nginx and client

--- a/setup-scripts/setup-health-check-scripts.sh
+++ b/setup-scripts/setup-health-check-scripts.sh
@@ -5,7 +5,7 @@ set -e # exit on first error
 sudo apt-get update
 sudo apt-get -y install python3-pip
 
-pip3 install discord.py python-dotenv requests elasticsearch-curator
+pip3 install DiscordWebhook python-dotenv requests elasticsearch-curator
 
 # add cron entries to user crontab
 crontab -u user /home/user/skynet-webportal/setup-scripts/support/crontab

--- a/setup-scripts/support/sia.env
+++ b/setup-scripts/support/sia.env
@@ -7,4 +7,8 @@ SIA_WALLET_PASSWORD=""
 # portal specific environment variables
 API_PORT="9980"
 PORTAL_NAME=""
-DISCORD_BOT_TOKEN=""
+
+# discord integration
+DISCORD_WEBHOOK_URL=""
+DISCORD_MENTION_USER_ID=""
+DISCORD_MENTION_ROLE_ID=""


### PR DESCRIPTION
We are moving away from having a bot to using webhooks for discord notifications - they are a lot simpler and we lost our bot so that's that.

## Breaking change

- added 3 new env variables:
  - `DISCORD_WEBHOOK_URL` **[required]** - it has to be discord webhook url that you generate
  - `DISCORD_MENTION_USER_ID` [optional] - it's a discord user id (not user name) that should be mentioned
  - `DISCORD_MENTION_ROLE_ID` [optional] - it's a disrcord role id (not role name) that should be mentioned

You can find user id or role id by writing `\@some_user_name` or `\@some_role_name` on discord - the id is just the number that looks like ie `699294748220850346`.

Deprecated env variables:

- `DISCORD_BOT_TOKEN` - not used any more
- `DISCORD_BOT_CHANNEL` - not used any more, hooks only report to one channel and you select it upon creation of the hook
- `DISCORD_BOT_NOTIFY_ROLE` - not used any more, by default we don't do any mention unless you set it in one of those new env variables

## migration

- you need to install `DiscordWebhook` package: `pip3 install DiscordWebhook`

### For siasky.net

- set `DISCORD_WEBHOOK_URL` to our secret webhook url (should report to `#skynet-server-health` channel)
- set `DISCORD_MENTION_ROLE_ID` to `699294748220850346` - it's a `@skynet-prod` role id

### For siasky dev servers

- set `DISCORD_WEBHOOK_URL` to our secret webhook url (should report to `#skynet-server-health-dev` channel)