### PR TITLE
request skylink v2 instead of v1

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -454,11 +454,7 @@ server {
 		proxy_read_timeout 600;
 		proxy_set_header User-Agent: Sia-Agent;
 		
-		# in case the requested skylink was v2 and we already resolved it to skylink v1, we're going to pass resolved 
-		# skylink v1 to skyd to save that extra skylink v2 lookup in skyd but in turn, in case skyd returns a redirect 
-		# we need to rewrite the skylink v1 to skylink v2 in the location header with proxy_redirect
-		proxy_redirect $skylink_v1 $skylink_v2;
-		proxy_pass http://siad/skynet/skylink/$skylink_v1$path$is_args$args;
+		proxy_pass http://siad/skynet/skylink/$skylink_v2$path$is_args$args;
 	}
 
 	location @dnslink_lookup {

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -454,7 +454,7 @@ server {
 		proxy_read_timeout 600;
 		proxy_set_header User-Agent: Sia-Agent;
 		
-		proxy_pass http://siad/skynet/skylink/$skylink_v2$path$is_args$args;
+		proxy_pass http://siad/skynet/skylink/$skylink$path$is_args$args;
 	}
 
 	location @dnslink_lookup {


### PR DESCRIPTION
we need to request skylink v2 instead of skylink v1 even if it's resolved already because skylink v2 response contains proof header