### PR TITLE
os.getenv doesn't take default value in lua

### DIFF
--- a/docker-compose.accounts.yml
+++ b/docker-compose.accounts.yml
@@ -9,7 +9,7 @@ x-logging: &default-logging
 services:
   nginx:
     environment:
-      - ACCOUNTS_ENABLED=1
+      - ACCOUNTS_ENABLED=true
     volumes:
       - ./docker/accounts/nginx.account.conf:/etc/nginx/conf.extra.d/nginx.account.conf:ro
     depends_on:
@@ -17,7 +17,7 @@ services:
 
   health-check:
     environment:
-      - ACCOUNTS_ENABLED=1
+      - ACCOUNTS_ENABLED=true
 
   accounts:
     build:

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -273,7 +273,7 @@ server {
 
 		access_by_lua_block {
 			-- this block runs only when accounts are enabled
-			if os.getenv("ACCOUNTS_ENABLED", "0") == "0" then return end
+			if os.getenv("ACCOUNTS_ENABLED") ~= "0" then return end
 
 			local res = ngx.location.capture("/accounts/user/limits", { copy_all_vars = true })
 			if res.status == ngx.HTTP_OK then
@@ -310,7 +310,7 @@ server {
 
 		# access_by_lua_block {
 		# 	-- this block runs only when accounts are enabled
-		# 	if os.getenv("ACCOUNTS_ENABLED", "0") == "0" then return end
+		# 	if os.getenv("ACCOUNTS_ENABLED") ~= "1" then return end
 
 		# 	ngx.var.upload_limit_rate = 5 * 1024 * 1024
 		# 	local res = ngx.location.capture("/accounts/user", { copy_all_vars = true })
@@ -352,7 +352,7 @@ server {
 			ngx.req.set_header("SkynetMaxUploadSize", 1073741824)
 
 			-- this block runs only when accounts are enabled
-			if os.getenv("ACCOUNTS_ENABLED", "0") == "0" then return end
+			if os.getenv("ACCOUNTS_ENABLED") ~= "1" then return end
 
 			-- fetch account limits and set max upload size accordingly
 			local res = ngx.location.capture("/accounts/user/limits", { copy_all_vars = true })
@@ -441,7 +441,7 @@ server {
 			end
 
 			-- this block runs only when accounts are enabled
-			if os.getenv("ACCOUNTS_ENABLED", "0") == "0" then return end
+			if os.getenv("ACCOUNTS_ENABLED") ~= "1" then return end
 
 			local res = ngx.location.capture("/accounts/user/limits", { copy_all_vars = true })
 			if res.status == ngx.HTTP_OK then
@@ -527,7 +527,7 @@ server {
 		content_by_lua_block {
 			local json = require('cjson')
 			-- this block runs only when accounts are enabled
-			if os.getenv("ACCOUNTS_ENABLED", "0") == "0" then
+			if os.getenv("ACCOUNTS_ENABLED") ~= "1" then
 				ngx.say(json.encode{authenticated = false})
 				return ngx.exit(ngx.HTTP_OK)
 			end

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -273,7 +273,7 @@ server {
 
 		access_by_lua_block {
 			-- this block runs only when accounts are enabled
-			if os.getenv("ACCOUNTS_ENABLED") ~= "0" then return end
+			if os.getenv("ACCOUNTS_ENABLED") ~= "true" then return end
 
 			local res = ngx.location.capture("/accounts/user/limits", { copy_all_vars = true })
 			if res.status == ngx.HTTP_OK then
@@ -310,7 +310,7 @@ server {
 
 		# access_by_lua_block {
 		# 	-- this block runs only when accounts are enabled
-		# 	if os.getenv("ACCOUNTS_ENABLED") ~= "1" then return end
+		# 	if os.getenv("ACCOUNTS_ENABLED") ~= "true" then return end
 
 		# 	ngx.var.upload_limit_rate = 5 * 1024 * 1024
 		# 	local res = ngx.location.capture("/accounts/user", { copy_all_vars = true })
@@ -352,7 +352,7 @@ server {
 			ngx.req.set_header("SkynetMaxUploadSize", 1073741824)
 
 			-- this block runs only when accounts are enabled
-			if os.getenv("ACCOUNTS_ENABLED") ~= "1" then return end
+			if os.getenv("ACCOUNTS_ENABLED") ~= "true" then return end
 
 			-- fetch account limits and set max upload size accordingly
 			local res = ngx.location.capture("/accounts/user/limits", { copy_all_vars = true })
@@ -441,7 +441,7 @@ server {
 			end
 
 			-- this block runs only when accounts are enabled
-			if os.getenv("ACCOUNTS_ENABLED") ~= "1" then return end
+			if os.getenv("ACCOUNTS_ENABLED") ~= "true" then return end
 
 			local res = ngx.location.capture("/accounts/user/limits", { copy_all_vars = true })
 			if res.status == ngx.HTTP_OK then
@@ -527,7 +527,7 @@ server {
 		content_by_lua_block {
 			local json = require('cjson')
 			-- this block runs only when accounts are enabled
-			if os.getenv("ACCOUNTS_ENABLED") ~= "1" then
+			if os.getenv("ACCOUNTS_ENABLED") ~= "true" then
 				ngx.say(json.encode{authenticated = false})
 				return ngx.exit(ngx.HTTP_OK)
 			end

--- a/docker/nginx/conf.d/include/track-download
+++ b/docker/nginx/conf.d/include/track-download
@@ -1,7 +1,7 @@
 # register the download in accounts service (cookies should contain jwt)
 log_by_lua_block {
     -- this block runs only when accounts are enabled
-    if os.getenv("ACCOUNTS_ENABLED", "0") == "0" then return end
+    if os.getenv("ACCOUNTS_ENABLED") ~= "1" then return end
 
     local skylink = ngx.header["Skynet-Skylink"]
     if skylink and ngx.status >= ngx.HTTP_OK and ngx.status < ngx.HTTP_SPECIAL_RESPONSE then

--- a/docker/nginx/conf.d/include/track-download
+++ b/docker/nginx/conf.d/include/track-download
@@ -1,7 +1,7 @@
 # register the download in accounts service (cookies should contain jwt)
 log_by_lua_block {
     -- this block runs only when accounts are enabled
-    if os.getenv("ACCOUNTS_ENABLED") ~= "1" then return end
+    if os.getenv("ACCOUNTS_ENABLED") ~= "true" then return end
 
     local skylink = ngx.header["Skynet-Skylink"]
     if skylink and ngx.status >= ngx.HTTP_OK and ngx.status < ngx.HTTP_SPECIAL_RESPONSE then

--- a/docker/nginx/conf.d/include/track-registry
+++ b/docker/nginx/conf.d/include/track-registry
@@ -1,7 +1,7 @@
 # register the registry access in accounts service (cookies should contain jwt)
 log_by_lua_block {
     -- this block runs only when accounts are enabled
-    if os.getenv("ACCOUNTS_ENABLED") ~= "1" then return end
+    if os.getenv("ACCOUNTS_ENABLED") ~= "true" then return end
 
     if ngx.status == ngx.HTTP_OK or ngx.status == ngx.HTTP_NOT_FOUND then
         local http = require("socket.http")

--- a/docker/nginx/conf.d/include/track-registry
+++ b/docker/nginx/conf.d/include/track-registry
@@ -1,7 +1,7 @@
 # register the registry access in accounts service (cookies should contain jwt)
 log_by_lua_block {
     -- this block runs only when accounts are enabled
-    if os.getenv("ACCOUNTS_ENABLED", "0") == "0" then return end
+    if os.getenv("ACCOUNTS_ENABLED") ~= "1" then return end
 
     if ngx.status == ngx.HTTP_OK or ngx.status == ngx.HTTP_NOT_FOUND then
         local http = require("socket.http")

--- a/docker/nginx/conf.d/include/track-upload
+++ b/docker/nginx/conf.d/include/track-upload
@@ -1,7 +1,7 @@
 # register the upload in accounts service (cookies should contain jwt)
 log_by_lua_block {
     -- this block runs only when accounts are enabled
-    if os.getenv("ACCOUNTS_ENABLED", "0") == "0" then return end
+    if os.getenv("ACCOUNTS_ENABLED") ~= "1" then return end
 
     local skylink = ngx.header["Skynet-Skylink"]
     if skylink and ngx.status >= ngx.HTTP_OK and ngx.status < ngx.HTTP_SPECIAL_RESPONSE then

--- a/docker/nginx/conf.d/include/track-upload
+++ b/docker/nginx/conf.d/include/track-upload
@@ -1,7 +1,7 @@
 # register the upload in accounts service (cookies should contain jwt)
 log_by_lua_block {
     -- this block runs only when accounts are enabled
-    if os.getenv("ACCOUNTS_ENABLED") ~= "1" then return end
+    if os.getenv("ACCOUNTS_ENABLED") ~= "true" then return end
 
     local skylink = ngx.header["Skynet-Skylink"]
     if skylink and ngx.status >= ngx.HTTP_OK and ngx.status < ngx.HTTP_SPECIAL_RESPONSE then

--- a/packages/health-check/src/checks/critical.js
+++ b/packages/health-check/src/checks/critical.js
@@ -166,7 +166,7 @@ const checks = [
   directServerApiAccessCheck,
 ];
 
-if (process.env.ACCOUNTS_ENABLED === "1") {
+if (process.env.ACCOUNTS_ENABLED === "true") {
   checks.push(accountHealthCheck, accountWebsiteCheck);
 }
 

--- a/packages/health-check/src/index.js
+++ b/packages/health-check/src/index.js
@@ -4,7 +4,7 @@ if (!process.env.SKYNET_PORTAL_API) {
   throw new Error("You need to provide SKYNET_PORTAL_API environment variable");
 }
 
-if (process.env.ACCOUNTS_ENABLED === "1" && !process.env.SKYNET_DASHBOARD_URL) {
+if (process.env.ACCOUNTS_ENABLED === "true" && !process.env.SKYNET_DASHBOARD_URL) {
   throw new Error("You need to provide SKYNET_DASHBOARD_URL environment variable when accounts are enabled");
 }
 


### PR DESCRIPTION
1. by mistake, turns out we're always calling accounts service even if the accounts are disabled - produces bunch of errors on our maintenance servers that don't run with accounts
2. replace "1" as an enabled value with more verbose "true"