### PR TITLE
disable slice module

### DIFF
--- a/docker/nginx/conf.d/include/proxy-cache-downloads
+++ b/docker/nginx/conf.d/include/proxy-cache-downloads
@@ -1,11 +1,6 @@
 set $nocache 0; # internal variable for bypassing the cache, nginx expects 0/1 for boolean
 proxy_cache skynet; # cache name
-slice 1m;
-proxy_http_version 1.1; # upgrade if necessary because 1.0 does not support byte-range requests
-proxy_set_header Range $slice_range; # pass slice range to proxy
-proxy_cache_key $skylink_v1$path$arg_format$arg_attachment$slice_range; # use just the uri path, format and attachment args and slice range
-proxy_cache_min_uses 3; # cache responses after 3 requests of the same file
+proxy_cache_key $skylink_v1$path$arg_format$arg_attachment$arg_start$arg_end$http_range; # unique cache key
 proxy_cache_valid 200 206 24h; # cache 200 and 206 responses for 24 hours
-proxy_cache_lock on; # queue cache requests for the same resource until it is fully cached
 proxy_cache_bypass $nocache $cookie_nocache $arg_nocache; # add cache bypass option
 add_header X-Proxy-Cache $upstream_cache_status; # add response header to indicate cache hits and misses

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -66,6 +66,10 @@ http {
 
     #gzip  on;
 
+    # globally enable http 1.1 on all proxied requests
+    # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version
+    proxy_http_version 1.1;
+
     # include skynet-portal-api and skynet-server-api header on every request
     header_filter_by_lua_block {
         ngx.header["Skynet-Portal-Api"] = os.getenv("SKYNET_PORTAL_API")


### PR DESCRIPTION
- disable slice module
  - it doesn't play well with range requests that specify range in request arguments
  - it doesn't play well with error codes returned from skyd on directory resolution integration
  - skyd now supports data streaming
- change proxy_cache_key removing slice and adding start and end arguments and range header
- decrease proxy_cache_min_uses to default 1 to cache more aggressively (still only for 24 hours)
- move proxy_http_version setting to 1.1 to be a globally set on all proxy connections since there is no reason to use 1.0 nowadays and 1.1 supports more features