### PR TITLE
Proof not showing up

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -441,7 +441,7 @@ server {
 					local json = require('cjson')
 					local resolve = json.decode(res.body)
 					ngx.var.skylink_v1 = resolve.skylink
-					ngx.var.proof = res.header["Skynet-Proof"]
+					ngx.var.skynet_proof = res.header["Skynet-Proof"]
 				end
 			end
 
@@ -458,7 +458,7 @@ server {
 
 		header_filter_by_lua_block {
 			if ngx.var.proof then
-				ngx.header["Skynet-Proof"] = ngx.var.proof
+				ngx.header["Skynet-Proof"] = ngx.var.skynet_proof
 			end
 		}
 

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -428,7 +428,7 @@ server {
 
 		# variable for Skynet-Proof header that we need to inject 
 		# into a response if the request was for skylink v2
-		set $skynet_proof;
+		set $skynet_proof '';
 
 		access_by_lua_block {
 			-- detect whether requested skylink is v2

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -457,7 +457,7 @@ server {
 		}
 
 		header_filter_by_lua_block {
-			if ngx.var.proof then
+			if ngx.var.skynet_proof then
 				ngx.header["Skynet-Proof"] = ngx.var.skynet_proof
 			end
 		}

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -426,6 +426,10 @@ server {
 		set $skylink_v1 $skylink;
 		set $skylink_v2 $skylink;
 
+		# variable for Skynet-Proof header that we need to inject 
+		# into a response if the request was for skylink v2
+		set $skynet_proof;
+
 		access_by_lua_block {
 			-- detect whether requested skylink is v2
 			local isBase32v2 = string.len(ngx.var.skylink) == 55 and string.sub(ngx.var.skylink, 0, 2) == "04"
@@ -437,6 +441,7 @@ server {
 					local json = require('cjson')
 					local resolve = json.decode(res.body)
 					ngx.var.skylink_v1 = resolve.skylink
+					ngx.var.proof = res.header["Skynet-Proof"]
 				end
 			end
 
@@ -451,10 +456,16 @@ server {
 			end
 		}
 
+		header_filter_by_lua_block {
+			if ngx.var.proof then
+				ngx.header["Skynet-Proof"] = ngx.var.proof
+			end
+		}
+
 		proxy_read_timeout 600;
 		proxy_set_header User-Agent: Sia-Agent;
 		
-		proxy_pass http://siad/skynet/skylink/$skylink$path$is_args$args;
+		proxy_pass http://siad/skynet/skylink/$skylink_v1$path$is_args$args;
 	}
 
 	location @dnslink_lookup {

--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -457,6 +457,10 @@ server {
 		}
 
 		header_filter_by_lua_block {
+			-- not empty skynet_proof means this is a skylink v2 request
+			-- so we should replace the Skynet-Proof header with the one
+			-- we got from /skynet/resolve/ endpoint, otherwise we would
+			-- be serving cached empty v1 skylink Skynet-Proof header
 			if ngx.var.skynet_proof then
 				ngx.header["Skynet-Proof"] = ngx.var.skynet_proof
 			end


### PR DESCRIPTION
In https://github.com/SkynetLabs/skynet-webportal/pull/990 I replaced request to resolved skylink v1 with skylink v2 request to make sure we're getting correct response headers. The issue was that Skynet-Proof is empty when requesting skylink v1 because it needs to come from request to skynet v2.

The solution is to go back to requesting skylink v1 because it gives us no edge to request skylink v2 now but also to add the Skynet-Proof header (we get it from resolving the skylink v2 anyway) in header filter hook.