### PR TITLE
increase size of the buffer to fit jwt in cache key

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -543,6 +543,7 @@ server {
 		proxy_cache skynet; # use general nginx cache
 		proxy_cache_key $uri+$skynet_jwt; # include skynet-jwt cookie (mapped to skynet_jwt)
 		proxy_cache_valid 200 401 1m; # cache success and unauthorized responses for 1 minute
+		proxy_buffer_size 8k; # increase size of the buffer to fit jwt in cache key
 
 		rewrite /accounts(.*) $1 break; # drop the /accounts prefix from uri
 		proxy_pass http://10.10.10.70:3000; # hardcoded ip because accounts might not be available


### PR DESCRIPTION
> proxy_buffer_size 4096 is not enough for cache key, it should be increased to at least 5120