### PR TITLE
fix broken skylink v2 redirects

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -446,6 +446,10 @@ server {
 		proxy_read_timeout 600;
 		proxy_set_header User-Agent: Sia-Agent;
 		
+		# in case the requested skylink was v2 and we already resolved it to skylink v1, we're going to pass resolved 
+		# skylink v1 to skyd to save that extra skylink v2 lookup in skyd but in turn, in case skyd returns a redirect 
+		# we need to rewrite the skylink v1 to skylink v2 in the location header with proxy_redirect
+		proxy_redirect $skylink_v1 $skylink_v2;
 		proxy_pass http://siad/skynet/skylink/$skylink_v1$path$is_args$args;
 	}
 


### PR DESCRIPTION
added back missing rewrite from https://github.com/SkynetLabs/skynet-webportal/pull/946 - forgot to put it back once we changed back from requesting skylinks v2 to v1 again

https://siasky.net/AQBUUNFGvF261JuvCZjEBQILdfB1UqVmaWuLS8MKPv82Yw
should redirect to
https://siasky.net/AQBUUNFGvF261JuvCZjEBQILdfB1UqVmaWuLS8MKPv82Yw/
instead it redirects to skylink v1 - this pr fixes it