### PR TITLE
bump worker_connections number and auto detect worker_processes number

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -16,8 +16,8 @@
 # See https://github.com/openresty/docker-openresty/blob/master/README.md#nginx-config-files
 #
 
-user  root;
-worker_processes  1;
+user root;
+worker_processes auto;
 
 #error_log  logs/error.log;
 #error_log  logs/error.log  notice;
@@ -31,7 +31,7 @@ env SKYNET_SERVER_API;
 env ACCOUNTS_ENABLED;
 
 events {
-    worker_connections  1024;
+    worker_connections 8192;
 }
 
 


### PR DESCRIPTION
We're getting errors:
> 1024 worker_connections are not enough

This means we need to increase number of connections available on the servers since it's either ddos or heavy load - currently skyd is under higher load and response times are higher so there is more open connections than usual.
