### PR TITLE
Update handshake chain migration in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,9 +103,8 @@ services:
     build:
       context: ./docker/handshake
       dockerfile: Dockerfile
-  # Uncomment this line if you need to migrate the handshake db for the chain
-  # migration.  For new portal set ups this line does not appear to be needed.
-  # command: --chain-migrate=1 --wallet-migrate=1
+    # Migration.  
+    command: --chain-migrate=1 --wallet-migrate=1
     container_name: handshake
     restart: unless-stopped
     logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,6 @@ services:
     build:
       context: ./docker/handshake
       dockerfile: Dockerfile
-    # Migration.  
     command: --chain-migrate=1 --wallet-migrate=1
     container_name: handshake
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,9 @@ services:
     build:
       context: ./docker/handshake
       dockerfile: Dockerfile
-    command: --chain-migrate=1 --wallet-migrate=1
+  # Uncomment this line if you need to migrate the handshake db for the chain
+  # migration.  For new portal set ups this line does not appear to be needed.
+  # command: --chain-migrate=1 --wallet-migrate=1
     container_name: handshake
     restart: unless-stopped
     logging: *default-logging

--- a/docker/handshake/Dockerfile
+++ b/docker/handshake/Dockerfile
@@ -3,7 +3,11 @@ FROM node:16.5.0-alpine
 WORKDIR /opt/hsd
 
 RUN apk update && apk add bash unbound-dev gmp-dev g++ gcc make python2 git
-# Checkout a specific commit until Handshake releases 2.4.0 then we should switch to that tag.
+# Checkout a specific commit until Handshake releases the next release after
+# 2.4.0 then we should switch to that tag.
+#
+# The commit we are targetting right now contains a fix for handling the chain
+# migration code for new portals.
 RUN git clone https://github.com/handshake-org/hsd.git /opt/hsd && \
     cd /opt/hsd && git checkout 6f0927db32723d6320c8bff255a6ccf70b2ccd32 && cd -
 RUN npm install --production

--- a/docker/handshake/Dockerfile
+++ b/docker/handshake/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /opt/hsd
 RUN apk update && apk add bash unbound-dev gmp-dev g++ gcc make python2 git
 # Checkout a specific commit until Handshake releases 2.4.0 then we should switch to that tag.
 RUN git clone https://github.com/handshake-org/hsd.git /opt/hsd && \
-    cd /opt/hsd && git checkout 3870234780240faf571426e790ea412dc6592622 && cd -
+    cd /opt/hsd && git checkout 6f0927db32723d6320c8bff255a6ccf70b2ccd32 && cd -
 RUN npm install --production
 
 ENV PATH="${PATH}:/opt/hsd/bin:/opt/hsd/node_modules/.bin"


### PR DESCRIPTION
When setting up a new portal I found that this command needs to be commented out in order for a new handshake node to start. 

It should stay in as a comment for existing portals