### PR TITLE
increase disk space size that warrants a warning

### DIFF
--- a/setup-scripts/health-checker.py
+++ b/setup-scripts/health-checker.py
@@ -35,8 +35,8 @@ DISCORD_MAX_MESSAGE_LENGTH = 1900
 GB = 1 << 30  # 1 GiB in bytes
 
 # Free disk space threshold used for notices and shutting down siad.
-FREE_DISK_SPACE_THRESHOLD = 50 * GB
-FREE_DISK_SPACE_THRESHOLD_CRITICAL = 20 * GB
+FREE_DISK_SPACE_THRESHOLD = 100 * GB
+FREE_DISK_SPACE_THRESHOLD_CRITICAL = 60 * GB
 
 setup()
 


### PR DESCRIPTION
with cache size increased to 50 GB (https://github.com/SkynetLabs/skynet-webportal/pull/1060) we need to make sure we always have a good buffer of disk space and we don't run up due to any unforeseen events like logs overflow from different services