### PR TITLE
add missing skylink headers

### DIFF
--- a/docker/nginx/conf.d/client.conf
+++ b/docker/nginx/conf.d/client.conf
@@ -221,6 +221,9 @@ server {
 
 		# in case siad returns location header, we need to replace the skylink with the domain name
 		header_filter_by_lua_block {
+			ngx.header["Skynet-Portal-Api"] = os.getenv("SKYNET_PORTAL_API")
+			ngx.header["Skynet-Server-Api"] = os.getenv("SKYNET_SERVER_API")
+			
 			if ngx.header.location then
 				-- match hns domain from the request_uri
 				local hns_domain_name = string.match(ngx.var.request_uri, "/hns/([^/?]+)")
@@ -342,6 +345,9 @@ server {
 
 		# extract skylink from base64 encoded upload metadata and assign to a proper header
 		header_filter_by_lua_block {
+			ngx.header["Skynet-Portal-Api"] = os.getenv("SKYNET_PORTAL_API")
+			ngx.header["Skynet-Server-Api"] = os.getenv("SKYNET_SERVER_API")
+
 			if ngx.header["Upload-Metadata"] then
 				local encodedSkylink = string.match(ngx.header["Upload-Metadata"], "Skylink ([^,?]+)")
 
@@ -434,6 +440,9 @@ server {
 		}
 
 		header_filter_by_lua_block {
+			ngx.header["Skynet-Portal-Api"] = os.getenv("SKYNET_PORTAL_API")
+			ngx.header["Skynet-Server-Api"] = os.getenv("SKYNET_SERVER_API")
+
 			-- not empty skynet_proof means this is a skylink v2 request
 			-- so we should replace the Skynet-Proof header with the one
 			-- we got from /skynet/resolve/ endpoint, otherwise we would


### PR DESCRIPTION
`header_filter_by_lua_block` can only be called once in the request lifecycle so if location uses it, the one from server block defined in nginx.conf is not executed - this is why we just need to copy&paste the headers to every header_filter_by_lua_block block we have

closes https://github.com/SkynetLabs/skynet-webportal/issues/1056