### PR TITLE
(high priority) cleanup unused discord import

### DIFF
--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import traceback, os, re, asyncio, requests, json, discord
+import traceback, os, re, asyncio, requests, json
 from bot_utils import setup, send_msg
 from random import randint
 from time import sleep

--- a/setup-scripts/bot_utils.py
+++ b/setup-scripts/bot_utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from datetime import datetime
 from discord_webhook import DiscordWebhook
 
-import urllib, json, os, traceback, discord, sys, re, subprocess, requests, io
+import urllib, json, os, traceback, sys, re, subprocess, requests, io
 
 # Load dotenv file if possible.
 # TODO: change all scripts to use named flags/params

--- a/setup-scripts/funds-checker.py
+++ b/setup-scripts/funds-checker.py
@@ -5,7 +5,7 @@ funds-checker runs simple checks on a portal node using the siad API and
 dispatches messages to a Discord channel.
 """
 
-import discord, traceback, asyncio, os
+import traceback, asyncio, os
 from bot_utils import setup, send_msg, siad, sc_precision
 
 setup()

--- a/setup-scripts/health-checker.py
+++ b/setup-scripts/health-checker.py
@@ -9,7 +9,6 @@ import time
 import traceback
 from datetime import datetime, timedelta
 
-import discord
 import requests
 from bot_utils import setup, send_msg, get_docker_container_ip
 


### PR DESCRIPTION
new servers don't have discord python library that we've used in the past and I forgot to remove the import from the scripts causing scripts to fail and we didn't notice because they ran in crontab

```sh
user@eu-fin-9:~/skynet-webportal$ /home/user/skynet-webportal/setup-scripts/blocklist-airtable.py /home/user/skynet-webportal/.env
Traceback (most recent call last):
  File "/home/user/skynet-webportal/setup-scripts/blocklist-airtable.py", line 3, in <module>
    import traceback, os, re, asyncio, requests, json, discord
ModuleNotFoundError: No module named 'discord'
```