### PR TITLE
include proof on resolver skylink requests

### DIFF
--- a/docker/nginx/conf.d/include/cors
+++ b/docker/nginx/conf.d/include/cors
@@ -13,4 +13,4 @@ more_set_headers 'Access-Control-Allow-Origin: $http_origin';
 more_set_headers 'Access-Control-Allow-Credentials: true';
 more_set_headers 'Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE';
 more_set_headers 'Access-Control-Allow-Headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,X-HTTP-Method-Override,upload-offset,upload-metadata,upload-length,tus-version,tus-resumable,tus-extension,tus-max-size,location';
-more_set_headers 'Access-Control-Expose-Headers: Content-Length,Content-Range,Skynet-File-Metadata,Skynet-Skylink,Skynet-Proof,Skynet-Portal-Api,Skynet-Server-Api,upload-offset,upload-metadata,upload-length,tus-version,tus-resumable,tus-extension,tus-max-size,location';
+more_set_headers 'Access-Control-Expose-Headers: Content-Length,Content-Range,Skynet-File-Metadata,Skynet-Skylink,Skynet-Requested-Skylink,Skynet-Proof,Skynet-Portal-Api,Skynet-Server-Api,upload-offset,upload-metadata,upload-length,tus-version,tus-resumable,tus-extension,tus-max-size,location';

--- a/docker/nginx/conf.d/include/cors
+++ b/docker/nginx/conf.d/include/cors
@@ -13,4 +13,4 @@ more_set_headers 'Access-Control-Allow-Origin: $http_origin';
 more_set_headers 'Access-Control-Allow-Credentials: true';
 more_set_headers 'Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE';
 more_set_headers 'Access-Control-Allow-Headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,X-HTTP-Method-Override,upload-offset,upload-metadata,upload-length,tus-version,tus-resumable,tus-extension,tus-max-size,location';
-more_set_headers 'Access-Control-Expose-Headers: Content-Length,Content-Range,Skynet-File-Metadata,Skynet-Skylink,Skynet-Requested-Skylink,Skynet-Proof,Skynet-Portal-Api,Skynet-Server-Api,upload-offset,upload-metadata,upload-length,tus-version,tus-resumable,tus-extension,tus-max-size,location';
+more_set_headers 'Access-Control-Expose-Headers: Content-Length,Content-Range,Skynet-File-Metadata,Skynet-Skylink,Skynet-Proof,Skynet-Portal-Api,Skynet-Server-Api,upload-offset,upload-metadata,upload-length,tus-version,tus-resumable,tus-extension,tus-max-size,location';

--- a/docker/nginx/conf.d/include/location-skylink
+++ b/docker/nginx/conf.d/include/location-skylink
@@ -19,9 +19,8 @@ limit_conn downloads_by_ip 100; # ddos protection: max 100 downloads at a time
 set $skylink_v1 $skylink;
 set $skylink_v2 $skylink;
 
-# initialise variables used to overwrite response headers for resolver skylink requests
+# initialise variable used to overwrite response header for resolver skylink requests
 set $override_skynet_proof "";
-set $override_skynet_requested_skylink "";
 
 # default download rate to unlimited
 set $limit_rate 0;
@@ -51,7 +50,6 @@ access_by_lua_block {
         local resolve = json.decode(res.body)
         ngx.var.skylink_v1 = resolve.skylink
         ngx.var.override_skynet_proof = res.headers["Skynet-Proof"]
-        ngx.var.override_skynet_requested_skylink = res.headers["Skynet-Requested-Skylink"]
     end
 
     -- this block runs only when accounts are enabled
@@ -80,11 +78,6 @@ header_filter_by_lua_block {
     -- override Skynet-Proof response header from resolver skylink response
     if ngx.var.override_skynet_proof ~= "" then
         ngx.header["Skynet-Proof"] = ngx.var.override_skynet_proof
-    end
-
-    -- override Skynet-Requested-Skylink response header from resolver skylink response
-    if ngx.var.override_skynet_requested_skylink ~= "" then
-        ngx.header["Skynet-Requested-Skylink"] = ngx.var.override_skynet_requested_skylink
     end
 }
 

--- a/docker/nginx/conf.d/include/location-skylink
+++ b/docker/nginx/conf.d/include/location-skylink
@@ -19,9 +19,9 @@ limit_conn downloads_by_ip 100; # ddos protection: max 100 downloads at a time
 set $skylink_v1 $skylink;
 set $skylink_v2 $skylink;
 
-# variable for Skynet-Proof header that we need to inject 
-# into a response if the request was for skylink v2
+# initialise variables used to overwrite headers with empty value
 set $skynet_proof '';
+set $skynet_requested_skylink '';
 
 # default download rate to unlimited
 set $limit_rate 0;
@@ -51,6 +51,7 @@ access_by_lua_block {
         local resolve = json.decode(res.body)
         ngx.var.skylink_v1 = resolve.skylink
         ngx.var.skynet_proof = res.headers["Skynet-Proof"]
+        ngx.var.skynet_requested_skylink = res.headers["Skynet-Requested-Skylink"]
     end
 
     -- this block runs only when accounts are enabled
@@ -76,12 +77,14 @@ header_filter_by_lua_block {
     ngx.header["Skynet-Portal-Api"] = os.getenv("SKYNET_PORTAL_API")
     ngx.header["Skynet-Server-Api"] = os.getenv("SKYNET_SERVER_API")
 
-    -- not empty skynet_proof means this is a skylink v2 request
-    -- so we should replace the Skynet-Proof header with the one
-    -- we got from /skynet/resolve/ endpoint, otherwise we would
-    -- be serving cached empty v1 skylink Skynet-Proof header
-    if ngx.var.skynet_proof and ngx.var.skynet_proof ~= "" then
-        ngx.header["Skynet-Proof"] = ngx.var.skynet_proof
+    -- override Skynet-Proof response header from resolver skylink response
+    if ngx.var.skynet_proof ~= "" then
+        ngx.header["Skynet-Proof"] = ngx.var.skynet_requested_skylink
+    end
+
+    -- override Skynet-Requested-Skylink response header from resolver skylink response
+    if ngx.var.skynet_requested_skylink ~= "" then
+        ngx.header["Skynet-Requested-Skylink"] = ngx.var.skynet_proof
     end
 }
 

--- a/docker/nginx/conf.d/include/location-skylink
+++ b/docker/nginx/conf.d/include/location-skylink
@@ -19,9 +19,9 @@ limit_conn downloads_by_ip 100; # ddos protection: max 100 downloads at a time
 set $skylink_v1 $skylink;
 set $skylink_v2 $skylink;
 
-# initialise variables used to overwrite headers with empty value
-set $skynet_proof '';
-set $skynet_requested_skylink '';
+# initialise variables used to overwrite response headers for resolver skylink requests
+set $override_skynet_proof "";
+set $override_skynet_requested_skylink "";
 
 # default download rate to unlimited
 set $limit_rate 0;
@@ -50,8 +50,8 @@ access_by_lua_block {
         local json = require('cjson')
         local resolve = json.decode(res.body)
         ngx.var.skylink_v1 = resolve.skylink
-        ngx.var.skynet_proof = res.headers["Skynet-Proof"]
-        ngx.var.skynet_requested_skylink = res.headers["Skynet-Requested-Skylink"]
+        ngx.var.override_skynet_proof = res.headers["Skynet-Proof"]
+        ngx.var.override_skynet_requested_skylink = res.headers["Skynet-Requested-Skylink"]
     end
 
     -- this block runs only when accounts are enabled
@@ -78,13 +78,13 @@ header_filter_by_lua_block {
     ngx.header["Skynet-Server-Api"] = os.getenv("SKYNET_SERVER_API")
 
     -- override Skynet-Proof response header from resolver skylink response
-    if ngx.var.skynet_proof ~= "" then
-        ngx.header["Skynet-Proof"] = ngx.var.skynet_requested_skylink
+    if ngx.var.override_skynet_proof ~= "" then
+        ngx.header["Skynet-Proof"] = ngx.var.override_skynet_proof
     end
 
     -- override Skynet-Requested-Skylink response header from resolver skylink response
-    if ngx.var.skynet_requested_skylink ~= "" then
-        ngx.header["Skynet-Requested-Skylink"] = ngx.var.skynet_proof
+    if ngx.var.override_skynet_requested_skylink ~= "" then
+        ngx.header["Skynet-Requested-Skylink"] = ngx.var.override_skynet_requested_skylink
     end
 }
 


### PR DESCRIPTION
In case of a resolver skylink request, we make a subrequest to resolve it into regular skylink and request the regular immutable skylink from skyd (because we need it to be cacheable request in nginx). Resolver skylink responses should include proof header so we need to add it after we get a regular skylink response.

☝️  this was already included in https://github.com/SkynetLabs/skynet-webportal/pull/1075 but this PR aims to rename the variables and simplify the description a bit