### PR TITLE
pin golang to 1.16.7

### DIFF
--- a/docker/sia/Dockerfile
+++ b/docker/sia/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang AS sia-builder
+FROM golang:1.16.7 AS sia-builder
 
 ENV GOOS linux
 ENV GOARCH amd64


### PR DESCRIPTION
1.17.0 introduces breaking change in `FileName` function

addressed in skyd in https://gitlab.com/SkynetLabs/skyd/-/merge_requests/244