### PR TITLE
do not expose Skynet-Requested-Skylink

### DIFF
--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -216,12 +216,28 @@ location /skynet/pin {
 location /skynet/metadata {
     include /etc/nginx/conf.d/include/cors;
 
+    header_filter_by_lua_block {
+        ngx.header["Skynet-Portal-Api"] = os.getenv("SKYNET_PORTAL_API")
+        ngx.header["Skynet-Server-Api"] = os.getenv("SKYNET_SERVER_API")
+
+        -- do not expose internal header
+        ngx.header["Skynet-Requested-Skylink"] = ""
+    }    
+
     proxy_set_header User-Agent: Sia-Agent;
     proxy_pass http://sia:9980;
 }
 
 location /skynet/resolve {
     include /etc/nginx/conf.d/include/cors;
+
+    header_filter_by_lua_block {
+        ngx.header["Skynet-Portal-Api"] = os.getenv("SKYNET_PORTAL_API")
+        ngx.header["Skynet-Server-Api"] = os.getenv("SKYNET_SERVER_API")
+
+        -- do not expose internal header
+        ngx.header["Skynet-Requested-Skylink"] = ""
+    }    
 
     proxy_set_header User-Agent: Sia-Agent;
     proxy_pass http://sia:9980;


### PR DESCRIPTION
Do not expose Skynet-Requested-Skylink header since it's an internal only header and portal users should not rely on it.

Skylink download endpoint doesn't need to hide it since it's requesting regular skylinks from skyd anyway and those will not have Skynet-Requested-Skylink attached.