### PR TITLE
fix tus upload limits not set

### DIFF
--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -173,6 +173,8 @@ location /skynet/tus {
         -- this block runs only when accounts are enabled
         if os.getenv("ACCOUNTS_ENABLED") ~= "true" then return end
 
+        local httpc = require("resty.http").new()
+
         -- fetch account limits and set max upload size accordingly
         local res, err = httpc:request_uri("http://10.10.10.70:3000/user/limits", {
             headers = { ["Cookie"] = "skynet-jwt=" .. ngx.var.skynet_jwt }


### PR DESCRIPTION
broken `rewrite_by_lua_block` section caused tus limits to default to 1GB

```
2021/09/02 08:05:34 [error] 414#414: *228588 lua entry thread aborted: runtime error: rewrite_by_lua(server.api:189):9: attempt to index global 'httpc' (a nil value)
stack traceback:
coroutine 0:
	rewrite_by_lua(server.api:189): in main chunk, client: 119.153.142.27, server: siasky.net, request: "POST /skynet/tus HTTP/2.0", host: "siasky.net", referrer: "https://siasky.net/"
```