### PR TITLE
round reporting datetime to full hours

### DIFF
--- a/setup-scripts/health-checker.py
+++ b/setup-scripts/health-checker.py
@@ -160,7 +160,9 @@ async def check_health():
     failed_records = []
     failed_records_file = None
 
-    time_limit = datetime.utcnow() - timedelta(hours=CHECK_HOURS)
+    time_limit = datetime.utcnow().replace(
+        minute=0, second=0, microsecond=0
+    ) - timedelta(hours=CHECK_HOURS)
 
     for critical in json_critical:
         time = datetime.strptime(critical["date"], "%Y-%m-%dT%H:%M:%S.%fZ")


### PR DESCRIPTION
Should resolve an issue where extended checks are not reported correctly, ie:

> https://eu-ger-5.siasky.net/: Portal manually disabled! All 99 critical checks passed. All 0 extended checks passed.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200942386000135/1200958910507798) by [Unito](https://www.unito.io)
