### PR TITLE
/skynet/tus should handle options response

### DIFF
--- a/docker/caddy/caddy.json.template
+++ b/docker/caddy/caddy.json.template
@@ -25,8 +25,7 @@
                     "provider": {
                       "name": "route53",
                       "max_retries": 100
-                    },
-                    ttl: "10m"
+                    }
                   }
                 }
               }

--- a/docker/caddy/caddy.json.template
+++ b/docker/caddy/caddy.json.template
@@ -25,7 +25,8 @@
                     "provider": {
                       "name": "route53",
                       "max_retries": 100
-                    }
+                    },
+                    ttl: "10m"
                   }
                 }
               }

--- a/docker/nginx/conf.d/include/cors
+++ b/docker/nginx/conf.d/include/cors
@@ -1,16 +1,9 @@
 if ($request_method = 'OPTIONS') {
-    more_set_headers 'Access-Control-Allow-Origin: $http_origin';
-    more_set_headers 'Access-Control-Allow-Credentials: true';
-    more_set_headers 'Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE';
-    more_set_headers 'Access-Control-Allow-Headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,If-None-Match,Cache-Control,Content-Type,Range,X-HTTP-Method-Override,upload-offset,upload-metadata,upload-length,tus-version,tus-resumable,tus-extension,tus-max-size,location';
+    include /etc/nginx/conf.d/include/cors-headers;
     more_set_headers 'Access-Control-Max-Age: 1728000';
     more_set_headers 'Content-Type: text/plain; charset=utf-8';
     more_set_headers 'Content-Length: 0';
     return 204;
 }
 
-more_set_headers 'Access-Control-Allow-Origin: $http_origin';
-more_set_headers 'Access-Control-Allow-Credentials: true';
-more_set_headers 'Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE';
-more_set_headers 'Access-Control-Allow-Headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,If-None-Match,Cache-Control,Content-Type,Range,X-HTTP-Method-Override,upload-offset,upload-metadata,upload-length,tus-version,tus-resumable,tus-extension,tus-max-size,location';
-more_set_headers 'Access-Control-Expose-Headers: Content-Length,Content-Range,ETag,Skynet-File-Metadata,Skynet-Skylink,Skynet-Proof,Skynet-Portal-Api,Skynet-Server-Api,upload-offset,upload-metadata,upload-length,tus-version,tus-resumable,tus-extension,tus-max-size,location';
+include /etc/nginx/conf.d/include/cors-headers;

--- a/docker/nginx/conf.d/include/cors-headers
+++ b/docker/nginx/conf.d/include/cors-headers
@@ -1,0 +1,5 @@
+more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+more_set_headers 'Access-Control-Allow-Credentials: true';
+more_set_headers 'Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE';
+more_set_headers 'Access-Control-Allow-Headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,If-None-Match,Cache-Control,Content-Type,Range,X-HTTP-Method-Override,upload-offset,upload-metadata,upload-length,tus-version,tus-resumable,tus-extension,tus-max-size,location';
+more_set_headers 'Access-Control-Expose-Headers: Content-Length,Content-Range,ETag,Skynet-File-Metadata,Skynet-Skylink,Skynet-Proof,Skynet-Portal-Api,Skynet-Server-Api,upload-offset,upload-metadata,upload-length,tus-version,tus-resumable,tus-extension,tus-max-size,location';

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -143,7 +143,7 @@ location /skynet/skyfile {
 
 # endpoint implementing resumable file uploads open protocol https://tus.io
 location /skynet/tus {
-    include /etc/nginx/conf.d/include/cors;
+    include /etc/nginx/conf.d/include/cors-headers; # include cors headers but do not overwrite OPTIONS response
     include /etc/nginx/conf.d/include/track-upload;
 
     # TUS chunks size is 40M + leaving 10M of breathing room


### PR DESCRIPTION
do not overwrite OPTIONS response on /skynet/tus endpoint

worked:
```
< HTTP/2 200
< server: openresty/1.19.9.1
< date: Fri, 10 Sep 2021 15:23:48 GMT
< content-length: 0
< tus-extension: creation,creation-with-upload,concatenation
< tus-resumable: 1.0.0
< tus-version: 1.0.0
< x-content-type-options: nosniff
< access-control-allow-credentials: true
< access-control-allow-methods: GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE
< access-control-allow-headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,If-None-Match,Cache-Control,Content-Type,Range,X-HTTP-Method-Override,upload-offset,upload-metadata,upload-length,tus-version,tus-resumable,tus-extension,tus-max-size,location
< access-control-expose-headers: Content-Length,Content-Range,ETag,Skynet-File-Metadata,Skynet-Skylink,Skynet-Proof,Skynet-Portal-Api,Skynet-Server-Api,upload-offset,upload-metadata,upload-length,tus-version,tus-resumable,tus-extension,tus-max-size,location
< skynet-portal-api: https://siasky.dev
< skynet-server-api: https://dev3.siasky.dev
<
* Connection #0 to host dev3.siasky.dev left intact
```