### PR TITLE
make caddy dns entries ttl 15 minutes

### DIFF
--- a/docker/caddy/caddy.json.template
+++ b/docker/caddy/caddy.json.template
@@ -25,7 +25,8 @@
                     "provider": {
                       "name": "route53",
                       "max_retries": 100
-                    }
+                    },
+                    ttl: "10m"
                   }
                 }
               }

--- a/docker/caddy/caddy.json.template
+++ b/docker/caddy/caddy.json.template
@@ -26,7 +26,7 @@
                       "name": "route53",
                       "max_retries": 100
                     },
-                    ttl: "10m"
+                    ttl: "15m"
                   }
                 }
               }


### PR DESCRIPTION
ttl for dns records should be 10 minutes - currently they don't expire and we have to go and remove the stranded ones manually



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200942386000135/1200960989922755) by [Unito](https://www.unito.io)
