### PR TITLE
fix transitioning to cli command

### DIFF
--- a/packages/health-check/Dockerfile
+++ b/packages/health-check/Dockerfile
@@ -4,11 +4,13 @@ RUN apk update && apk add dnsmasq
 
 WORKDIR /usr/app
 
+ENV PATH="/usr/app/bin:${PATH}"
+
 # schedule critical checks to run every 5 minutes (any failures will disable server)
-RUN echo '*/5 * * * * /usr/app/cli/run critical > /dev/stdout' >> /etc/crontabs/root
+RUN echo '*/5 * * * * /usr/app/bin/cli run critical > /dev/stdout' >> /etc/crontabs/root
 
 # schedule extended checks to run on every hour (optional checks, report only)
-RUN echo '0 * * * * /usr/app/cli/run extended > /dev/stdout' >> /etc/crontabs/root
+RUN echo '0 * * * * /usr/app/bin/cli run extended > /dev/stdout' >> /etc/crontabs/root
 
 COPY package.json yarn.lock ./
 
@@ -16,6 +18,7 @@ RUN yarn --frozen-lockfile
 
 COPY src src
 COPY cli cli
+COPY bin bin
 
 EXPOSE 3100
 ENV NODE_ENV production

--- a/packages/health-check/bin/cli
+++ b/packages/health-check/bin/cli
@@ -55,7 +55,7 @@ require("yargs/yargs")(process.argv.slice(2))
       const { getYesterdayISOString } = require("../src/utils");
       const createMiddleware = require("../src/checks/middleware");
       const db = require("../src/db");
-      const checks = require(`./src/checks/${type}`);
+      const checks = require(`../src/checks/${type}`);
       const middleware = await createMiddleware();
 
       const entry = {

--- a/packages/health-check/bin/cli
+++ b/packages/health-check/bin/cli
@@ -3,12 +3,15 @@
 process.env.NODE_ENV = process.env.NODE_ENV || "production";
 
 require("yargs/yargs")(process.argv.slice(2))
+  .help()
+  .demandCommand()
+  .strict(true)
   .command(
     "enable",
     "Mark portal as enabled",
     () => {},
     () => {
-      const db = require("./src/db");
+      const db = require("../src/db");
 
       db.set("disabled", false).write();
     }
@@ -18,7 +21,7 @@ require("yargs/yargs")(process.argv.slice(2))
     "Mark portal as disabled (provide meaningful reason)",
     () => {},
     ({ reason }) => {
-      const db = require("./src/db");
+      const db = require("../src/db");
 
       db.set("disabled", reason).write();
     }
@@ -49,9 +52,9 @@ require("yargs/yargs")(process.argv.slice(2))
       process.env.STATE_DIR = stateDir;
 
       const util = require("util");
-      const { getYesterdayISOString } = require("./src/utils");
-      const createMiddleware = require("./src/checks/middleware");
-      const db = require("./src/db");
+      const { getYesterdayISOString } = require("../src/utils");
+      const createMiddleware = require("../src/checks/middleware");
+      const db = require("../src/db");
       const checks = require(`./src/checks/${type}`);
       const middleware = await createMiddleware();
 

--- a/packages/health-check/cli/disable
+++ b/packages/health-check/cli/disable
@@ -1,3 +1,3 @@
 #!/bin/ash
 
-cli disable $@
+/usr/app/bin/cli disable $@

--- a/packages/health-check/cli/disable
+++ b/packages/health-check/cli/disable
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+cli disable $@

--- a/packages/health-check/cli/enable
+++ b/packages/health-check/cli/enable
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+cli enable $@

--- a/packages/health-check/cli/enable
+++ b/packages/health-check/cli/enable
@@ -1,3 +1,3 @@
 #!/bin/ash
 
-cli enable $@
+/usr/app/bin/cli enable $@

--- a/packages/health-check/cli/run
+++ b/packages/health-check/cli/run
@@ -1,3 +1,3 @@
 #!/bin/ash
 
-cli run $0
+/usr/app/bin/cli run $0

--- a/packages/health-check/cli/run
+++ b/packages/health-check/cli/run
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+cli run $0

--- a/setup-scripts/setup-docker-services.sh
+++ b/setup-scripts/setup-docker-services.sh
@@ -16,7 +16,7 @@ docker --version # sanity check
 sudo usermod -aG docker user
 
 # Install docker-compose
-sudo curl -L "https://github.com/docker/compose/releases/download/1.25.5/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 docker-compose --version # sanity check
 


### PR DESCRIPTION
you should use cli in a way like
- `docker exec health-check cli enable`
- `docker exec health-check cli disable temporary`
- `docker exec health-check cli run critical`
- `docker exec health-check cli run extended`

but for the transitioning period (when updating) we should allow also legacy format
- `docker exec health-check cli/enable`
- `docker exec health-check cli/disable temporary`
- `docker exec health-check cli/run critical`
- `docker exec health-check cli/run extended`