### PR TITLE
expose skylink api over external domains

### DIFF
--- a/docker/nginx/conf.d/include/location-hns
+++ b/docker/nginx/conf.d/include/location-hns
@@ -75,7 +75,7 @@ access_by_lua_block {
     end
 }
 
-# we proxy to another nginx location rather than directly to siad because we don't want to deal with caching here
+# we proxy to another nginx location rather than directly to siad because we do not want to deal with caching here
 proxy_pass https://127.0.0.1/$skylink$path$is_args$args;
 
 # in case siad returns location header, we need to replace the skylink with the domain name

--- a/docker/nginx/conf.d/include/location-skylink
+++ b/docker/nginx/conf.d/include/location-skylink
@@ -12,7 +12,7 @@ if ($request_method = PURGE) {
 limit_conn downloads_by_ip 100; # ddos protection: max 100 downloads at a time
 
 # $skylink_v1 and $skylink_v2 variables default to the same value but in case the requested skylink was:
-# a) skylink v1 - it wouldn't matter, no additional logic is executed
+# a) skylink v1 - it would not matter, no additional logic is executed
 # b) skylink v2 - in a lua block below we will resolve the skylink v2 into skylink v1 and update 
 #      $skylink_v1 variable so then the proxy request to skyd can be cached in nginx (proxy_cache_key 
 #      in proxy-cache-downloads includes $skylink_v1 as a part of the cache key)
@@ -91,7 +91,7 @@ limit_rate $limit_rate;
 proxy_read_timeout 600;
 proxy_set_header User-Agent: Sia-Agent;
 
-# in case the requested skylink was v2 and we already resolved it to skylink v1, we're going to pass resolved 
+# in case the requested skylink was v2 and we already resolved it to skylink v1, we are going to pass resolved 
 # skylink v1 to skyd to save that extra skylink v2 lookup in skyd but in turn, in case skyd returns a redirect 
 # we need to rewrite the skylink v1 to skylink v2 in the location header with proxy_redirect
 proxy_redirect $skylink_v1 $skylink_v2;

--- a/docker/nginx/conf.d/server/server.dnslink
+++ b/docker/nginx/conf.d/server/server.dnslink
@@ -11,15 +11,24 @@ location / {
         local res, err = httpc:request_uri("http://10.10.10.55:3100/dnslink/" .. ngx.var.host)
 
         if err or (res and res.status ~= ngx.HTTP_OK) then
-            ngx.status = (err and ngx.HTTP_INTERNAL_SERVER_ERROR) or res.status
-            ngx.header["content-type"] = "text/plain"
-            ngx.say(err or res.body)
-            ngx.exit(ngx.status)
+            -- check whether we can fallback to regular skylink request
+            local match_skylink = ngx.re.match(ngx.var.uri, "^/([a-zA-Z0-9-_]{46}|[a-z0-9]{55})(/.*)?")
+
+            if match_skylink then
+                ngx.var.skylink = match_skylink[1]
+                ngx.var.path = match_skylink[2]
+            else
+                ngx.status = (err and ngx.HTTP_INTERNAL_SERVER_ERROR) or res.status
+                ngx.header["content-type"] = "text/plain"
+                ngx.say(err or res.body)
+                ngx.exit(ngx.status)
+            end
         else
             ngx.var.skylink = res.body
-            ngx.var.skylink_v1 = ngx.var.skylink
-            ngx.var.skylink_v2 = ngx.var.skylink
         end
+                
+        ngx.var.skylink_v1 = ngx.var.skylink
+        ngx.var.skylink_v2 = ngx.var.skylink
     }
 
     include /etc/nginx/conf.d/include/location-skylink;

--- a/docker/nginx/conf.d/server/server.dnslink
+++ b/docker/nginx/conf.d/server/server.dnslink
@@ -16,7 +16,7 @@ location / {
 
             if match_skylink then
                 ngx.var.skylink = match_skylink[1]
-                ngx.var.path = match_skylink[2]
+                ngx.var.path = match_skylink[2] or "/"
             else
                 ngx.status = (err and ngx.HTTP_INTERNAL_SERVER_ERROR) or res.status
                 ngx.header["content-type"] = "text/plain"


### PR DESCRIPTION
In addition to dnslink, we want to allow people to alias siasky.net with their domain and expose any skylink.

let's say https://example.com sets CNAME to siasky.net - it can either
- use dnslink to point to a specific skylink
- do not set dnslink, it will be able to request any any skylink so https://example.com/3ACpC9Umme41zlWUgMQh1fw0sNwgWwyfDDhRQ9Sppz9hjQ would work as well as any other skylink