### PR TITLE
fix invalid json in config file

### DIFF
--- a/docker/caddy/caddy.json.template
+++ b/docker/caddy/caddy.json.template
@@ -26,7 +26,7 @@
                       "name": "route53",
                       "max_retries": 100
                     },
-                    ttl: "15m"
+                    "ttl": "15m"
                   }
                 }
               }


### PR DESCRIPTION
keys in json file should always be wrapped in quotes