### PR TITLE
work in progress: clean up env vars

### DIFF
--- a/docker-compose.accounts.yml
+++ b/docker-compose.accounts.yml
@@ -95,7 +95,7 @@ services:
     environment:
       - DSN=cockroach://root@cockroach:26257/defaultdb?max_conns=20&max_idle_conns=4&sslmode=verify-full&sslcert=/certs/node.crt&sslkey=/certs/node.key&sslrootcert=/certs/ca.crt
       - LOG_LEVEL=trace
-      - SERVE_PUBLIC_BASE_URL=${SKYNET_DASHBOARD_URL}/.ory/kratos/public/
+      - SERVE_PUBLIC_BASE_URL=https://account.${PORTAL_DOMAIN}/.ory/kratos/public/
       - SQA_OPT_OUT=true
     command: serve -c /etc/config/kratos/kratos.yml
     volumes:
@@ -118,9 +118,7 @@ services:
     env_file:
       - .env
     environment:
-      - NEXT_PUBLIC_SKYNET_PORTAL_API=${SKYNET_PORTAL_API}
-      - NEXT_PUBLIC_SKYNET_DASHBOARD_URL=${SKYNET_DASHBOARD_URL}
-      - NEXT_PUBLIC_KRATOS_BROWSER_URL=${SKYNET_DASHBOARD_URL}/.ory/kratos/public
+      - NEXT_PUBLIC_PORTAL_DOMAIN=${PORTAL_DOMAIN}
       - NEXT_PUBLIC_KRATOS_PUBLIC_URL=http://oathkeeper:4455/.ory/kratos/public
       - NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY}
     networks:

--- a/docker-compose.jaeger.yml
+++ b/docker-compose.jaeger.yml
@@ -10,7 +10,6 @@ services:
   sia:
     environment:
       - JAEGER_DISABLED=${JAEGER_DISABLED:-false} # Enable/Disable tracing
-      - JAEGER_SERVICE_NAME=${PORTAL_NAME:-Skyd} # change to e.g. eu-ger-1
       # Configuration
       # See https://github.com/jaegertracing/jaeger-client-go#environment-variables
       # for all options.

--- a/docker/caddy/caddy.json.template
+++ b/docker/caddy/caddy.json.template
@@ -26,7 +26,7 @@
                       "name": "route53",
                       "max_retries": 100
                     },
-                    "ttl": "1800"
+                    "ttl": "1h"
                   }
                 }
               }

--- a/docker/caddy/caddy.json.template
+++ b/docker/caddy/caddy.json.template
@@ -26,7 +26,7 @@
                       "name": "route53",
                       "max_retries": 100
                     },
-                    "ttl": "15m"
+                    "ttl": "1800"
                   }
                 }
               }

--- a/docker/caddy/caddy.json.template
+++ b/docker/caddy/caddy.json.template
@@ -25,8 +25,7 @@
                     "provider": {
                       "name": "route53",
                       "max_retries": 100
-                    },
-                    "ttl": "1h"
+                    }
                   }
                 }
               }

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -13,6 +13,7 @@ COPY conf.d.templates /etc/nginx/conf.d.templates
 CMD [ "bash", "-c", \
       "./mo < /etc/nginx/conf.d.templates/server.account.conf > /etc/nginx/conf.d/server.account.conf ; \
        ./mo < /etc/nginx/conf.d.templates/server.api.conf > /etc/nginx/conf.d/server.api.conf; \
+       ./mo < /etc/nginx/conf.d.templates/server.dnslink.conf > /etc/nginx/conf.d/server.dnslink.conf; \
        ./mo < /etc/nginx/conf.d.templates/server.hns.conf > /etc/nginx/conf.d/server.hns.conf; \
        ./mo < /etc/nginx/conf.d.templates/server.skylink.conf > /etc/nginx/conf.d/server.skylink.conf ; \
        /usr/local/openresty/bin/openresty '-g daemon off;'" \

--- a/docker/nginx/conf.d.templates/server.account.conf
+++ b/docker/nginx/conf.d.templates/server.account.conf
@@ -26,8 +26,8 @@
 	server {
 		server_name account.{{SERVER_DOMAIN}}; # example: account.eu-ger-1.siasky.net
 
-		set $portal_domain "{{SERVER_DOMAIN}}"
-		set $server_domain "{{SERVER_DOMAIN}}"
+		set $portal_domain "{{SERVER_DOMAIN}}";
+		set $server_domain "{{SERVER_DOMAIN}}";
 
 		include /etc/nginx/conf.d/server/server.http;
 
@@ -37,8 +37,8 @@
 	server {
 		server_name account.{{SERVER_DOMAIN}}; # example: account.eu-ger-1.siasky.net
 
-		set $portal_domain "{{SERVER_DOMAIN}}"
-		set $server_domain "{{SERVER_DOMAIN}}"
+		set $portal_domain "{{SERVER_DOMAIN}}";
+		set $server_domain "{{SERVER_DOMAIN}}";
 
 		ssl_certificate     /data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.{{SERVER_DOMAIN}}/wildcard_.{{SERVER_DOMAIN}}.crt;
 		ssl_certificate_key	/data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.{{SERVER_DOMAIN}}/wildcard_.{{SERVER_DOMAIN}}.key;

--- a/docker/nginx/conf.d.templates/server.account.conf
+++ b/docker/nginx/conf.d.templates/server.account.conf
@@ -2,12 +2,18 @@
 	{{#PORTAL_DOMAIN}}
 	server {
 		server_name account.{{PORTAL_DOMAIN}}; # example: account.siasky.net
+
+		set $portal_domain "{{PORTAL_DOMAIN}}";
+		set_by_lua_block $server_domain { return "{{SERVER_DOMAIN}}" or "{{PORTAL_DOMAIN}}" }
 		
 		include /etc/nginx/conf.d/server/server.http;
 	}
 
 	server {
 		server_name account.{{PORTAL_DOMAIN}}; # example: account.siasky.net
+
+		set $portal_domain "{{PORTAL_DOMAIN}}";
+		set_by_lua_block $server_domain { return "{{SERVER_DOMAIN}}" or "{{PORTAL_DOMAIN}}" }
 
 		ssl_certificate     /data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.{{PORTAL_DOMAIN}}/wildcard_.{{PORTAL_DOMAIN}}.crt;
 		ssl_certificate_key	/data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.{{PORTAL_DOMAIN}}/wildcard_.{{PORTAL_DOMAIN}}.key;
@@ -20,6 +26,9 @@
 	server {
 		server_name account.{{SERVER_DOMAIN}}; # example: account.eu-ger-1.siasky.net
 
+		set $portal_domain "{{SERVER_DOMAIN}}"
+		set $server_domain "{{SERVER_DOMAIN}}"
+
 		include /etc/nginx/conf.d/server/server.http;
 
 		set_by_lua_block $server_alias { return string.match("{{SERVER_DOMAIN}}", "^([^.]+)") }
@@ -27,6 +36,9 @@
 
 	server {
 		server_name account.{{SERVER_DOMAIN}}; # example: account.eu-ger-1.siasky.net
+
+		set $portal_domain "{{SERVER_DOMAIN}}"
+		set $server_domain "{{SERVER_DOMAIN}}"
 
 		ssl_certificate     /data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.{{SERVER_DOMAIN}}/wildcard_.{{SERVER_DOMAIN}}.crt;
 		ssl_certificate_key	/data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.{{SERVER_DOMAIN}}/wildcard_.{{SERVER_DOMAIN}}.key;

--- a/docker/nginx/conf.d.templates/server.api.conf
+++ b/docker/nginx/conf.d.templates/server.api.conf
@@ -1,12 +1,18 @@
 {{#PORTAL_DOMAIN}}
 server {
 	server_name {{PORTAL_DOMAIN}}; # example: siasky.net
+
+	set $portal_domain "{{PORTAL_DOMAIN}}";
+	set_by_lua_block $server_domain { return "{{SERVER_DOMAIN}}" or "{{PORTAL_DOMAIN}}" }
 	
 	include /etc/nginx/conf.d/server/server.http;
 }
 
 server {
 	server_name {{PORTAL_DOMAIN}}; # example: siasky.net
+
+	set $portal_domain "{{PORTAL_DOMAIN}}";
+	set_by_lua_block $server_domain { return "{{SERVER_DOMAIN}}" or "{{PORTAL_DOMAIN}}" }
 
 	ssl_certificate     /data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/{{PORTAL_DOMAIN}}/{{PORTAL_DOMAIN}}.crt;
 	ssl_certificate_key	/data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/{{PORTAL_DOMAIN}}/{{PORTAL_DOMAIN}}.key;
@@ -19,6 +25,9 @@ server {
 server {
 	server_name {{SERVER_DOMAIN}}; # example: eu-ger-1.siasky.net
 
+	set $portal_domain "{{SERVER_DOMAIN}}"
+	set $server_domain "{{SERVER_DOMAIN}}"
+
 	include /etc/nginx/conf.d/server/server.http;
 
 	set_by_lua_block $server_alias { return string.match("{{SERVER_DOMAIN}}", "^([^.]+)") }
@@ -26,6 +35,9 @@ server {
 
 server {
 	server_name {{SERVER_DOMAIN}}; # example: eu-ger-1.siasky.net
+
+	set $portal_domain "{{SERVER_DOMAIN}}"
+	set $server_domain "{{SERVER_DOMAIN}}"
 
 	ssl_certificate     /data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/{{SERVER_DOMAIN}}/{{SERVER_DOMAIN}}.crt;
 	ssl_certificate_key	/data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/{{SERVER_DOMAIN}}/{{SERVER_DOMAIN}}.key;

--- a/docker/nginx/conf.d.templates/server.api.conf
+++ b/docker/nginx/conf.d.templates/server.api.conf
@@ -25,8 +25,8 @@ server {
 server {
 	server_name {{SERVER_DOMAIN}}; # example: eu-ger-1.siasky.net
 
-	set $portal_domain "{{SERVER_DOMAIN}}"
-	set $server_domain "{{SERVER_DOMAIN}}"
+	set $portal_domain "{{SERVER_DOMAIN}}";
+	set $server_domain "{{SERVER_DOMAIN}}";
 
 	include /etc/nginx/conf.d/server/server.http;
 
@@ -36,8 +36,8 @@ server {
 server {
 	server_name {{SERVER_DOMAIN}}; # example: eu-ger-1.siasky.net
 
-	set $portal_domain "{{SERVER_DOMAIN}}"
-	set $server_domain "{{SERVER_DOMAIN}}"
+	set $portal_domain "{{SERVER_DOMAIN}}";
+	set $server_domain "{{SERVER_DOMAIN}}";
 
 	ssl_certificate     /data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/{{SERVER_DOMAIN}}/{{SERVER_DOMAIN}}.crt;
 	ssl_certificate_key	/data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/{{SERVER_DOMAIN}}/{{SERVER_DOMAIN}}.key;

--- a/docker/nginx/conf.d.templates/server.dnslink.conf
+++ b/docker/nginx/conf.d.templates/server.dnslink.conf
@@ -1,6 +1,9 @@
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
+
+	set $portal_domain "{{PORTAL_DOMAIN}}";
+	set_by_lua_block $server_domain { return "{{SERVER_DOMAIN}}" or "{{PORTAL_DOMAIN}}" }
     
     include /etc/nginx/conf.d/server/server.dnslink;
 }
@@ -8,6 +11,9 @@ server {
 server {
     listen 443 default_server;
     listen [::]:443 default_server;
+
+	set $portal_domain "{{PORTAL_DOMAIN}}";
+	set_by_lua_block $server_domain { return "{{SERVER_DOMAIN}}" or "{{PORTAL_DOMAIN}}" }
 
     ssl_certificate     /etc/ssl/local-certificate.crt;
     ssl_certificate_key /etc/ssl/local-certificate.key;

--- a/docker/nginx/conf.d.templates/server.hns.conf
+++ b/docker/nginx/conf.d.templates/server.hns.conf
@@ -26,8 +26,8 @@ server {
 server {
 	server_name *.hns.{{SERVER_DOMAIN}}; # example: *.hns.eu-ger-1.siasky.net
 
-	set $portal_domain "{{SERVER_DOMAIN}}"
-	set $server_domain "{{SERVER_DOMAIN}}"
+	set $portal_domain "{{SERVER_DOMAIN}}";
+	set $server_domain "{{SERVER_DOMAIN}}";
 	
 	include /etc/nginx/conf.d/server/server.http;
 
@@ -37,8 +37,8 @@ server {
 server {
 	server_name *.hns.{{SERVER_DOMAIN}}; # example: *.hns.eu-ger-1.siasky.net
 
-	set $portal_domain "{{SERVER_DOMAIN}}"
-	set $server_domain "{{SERVER_DOMAIN}}"
+	set $portal_domain "{{SERVER_DOMAIN}}";
+	set $server_domain "{{SERVER_DOMAIN}}";
 	
 	ssl_certificate     /data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.hns.{{SERVER_DOMAIN}}/wildcard_.hns.{{SERVER_DOMAIN}}.crt;
 	ssl_certificate_key	/data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.hns.{{SERVER_DOMAIN}}/wildcard_.hns.{{SERVER_DOMAIN}}.key;

--- a/docker/nginx/conf.d.templates/server.hns.conf
+++ b/docker/nginx/conf.d.templates/server.hns.conf
@@ -1,12 +1,18 @@
 {{#PORTAL_DOMAIN}}
 server {
 	server_name *.hns.{{PORTAL_DOMAIN}}; # example: *.hns.siasky.net
+
+	set $portal_domain "{{PORTAL_DOMAIN}}";
+	set_by_lua_block $server_domain { return "{{SERVER_DOMAIN}}" or "{{PORTAL_DOMAIN}}" }
 	
 	include /etc/nginx/conf.d/server/server.http;
 }
 
 server {
 	server_name *.hns.{{PORTAL_DOMAIN}}; # example: *.hns.siasky.net
+
+	set $portal_domain "{{PORTAL_DOMAIN}}";
+	set_by_lua_block $server_domain { return "{{SERVER_DOMAIN}}" or "{{PORTAL_DOMAIN}}" }
 	
 	ssl_certificate     /data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.hns.{{PORTAL_DOMAIN}}/wildcard_.hns.{{PORTAL_DOMAIN}}.crt;
 	ssl_certificate_key	/data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.hns.{{PORTAL_DOMAIN}}/wildcard_.hns.{{PORTAL_DOMAIN}}.key;
@@ -19,6 +25,9 @@ server {
 {{#SERVER_DOMAIN}}
 server {
 	server_name *.hns.{{SERVER_DOMAIN}}; # example: *.hns.eu-ger-1.siasky.net
+
+	set $portal_domain "{{SERVER_DOMAIN}}"
+	set $server_domain "{{SERVER_DOMAIN}}"
 	
 	include /etc/nginx/conf.d/server/server.http;
 
@@ -27,6 +36,9 @@ server {
 
 server {
 	server_name *.hns.{{SERVER_DOMAIN}}; # example: *.hns.eu-ger-1.siasky.net
+
+	set $portal_domain "{{SERVER_DOMAIN}}"
+	set $server_domain "{{SERVER_DOMAIN}}"
 	
 	ssl_certificate     /data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.hns.{{SERVER_DOMAIN}}/wildcard_.hns.{{SERVER_DOMAIN}}.crt;
 	ssl_certificate_key	/data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.hns.{{SERVER_DOMAIN}}/wildcard_.hns.{{SERVER_DOMAIN}}.key;

--- a/docker/nginx/conf.d.templates/server.skylink.conf
+++ b/docker/nginx/conf.d.templates/server.skylink.conf
@@ -36,8 +36,8 @@ server {
 server {
 	server_name *.{{SERVER_DOMAIN}}; # example: *.eu-ger-1.siasky.net
 
-	set $portal_domain "{{SERVER_DOMAIN}}"
-	set $server_domain "{{SERVER_DOMAIN}}"
+	set $portal_domain "{{SERVER_DOMAIN}}";
+	set $server_domain "{{SERVER_DOMAIN}}";
 	
 	ssl_certificate     /data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.{{SERVER_DOMAIN}}/wildcard_.{{SERVER_DOMAIN}}.crt;
 	ssl_certificate_key	/data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.{{SERVER_DOMAIN}}/wildcard_.{{SERVER_DOMAIN}}.key;

--- a/docker/nginx/conf.d.templates/server.skylink.conf
+++ b/docker/nginx/conf.d.templates/server.skylink.conf
@@ -2,11 +2,17 @@
 server {
 	server_name *.{{PORTAL_DOMAIN}}; # example: *.siasky.net
 
+	set $portal_domain "{{PORTAL_DOMAIN}}";
+	set_by_lua_block $server_domain { return "{{SERVER_DOMAIN}}" or "{{PORTAL_DOMAIN}}" }
+
 	include /etc/nginx/conf.d/server/server.http;
 }
 
 server {
 	server_name *.{{PORTAL_DOMAIN}}; # example: *.siasky.net
+
+	set $portal_domain "{{PORTAL_DOMAIN}}";
+	set_by_lua_block $server_domain { return "{{SERVER_DOMAIN}}" or "{{PORTAL_DOMAIN}}" }
 
 	ssl_certificate     /data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.{{PORTAL_DOMAIN}}/wildcard_.{{PORTAL_DOMAIN}}.crt;
 	ssl_certificate_key	/data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.{{PORTAL_DOMAIN}}/wildcard_.{{PORTAL_DOMAIN}}.key;
@@ -19,6 +25,9 @@ server {
 server {
 	server_name *.{{SERVER_DOMAIN}}; # example: *.eu-ger-1.siasky.net
 
+	set $portal_domain "{{SERVER_DOMAIN}}"
+	set $server_domain "{{SERVER_DOMAIN}}"
+
 	include /etc/nginx/conf.d/server/server.http;
 
 	set_by_lua_block $server_alias { return string.match("{{SERVER_DOMAIN}}", "^([^.]+)") }
@@ -26,6 +35,9 @@ server {
 
 server {
 	server_name *.{{SERVER_DOMAIN}}; # example: *.eu-ger-1.siasky.net
+
+	set $portal_domain "{{SERVER_DOMAIN}}"
+	set $server_domain "{{SERVER_DOMAIN}}"
 	
 	ssl_certificate     /data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.{{SERVER_DOMAIN}}/wildcard_.{{SERVER_DOMAIN}}.crt;
 	ssl_certificate_key	/data/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/wildcard_.{{SERVER_DOMAIN}}/wildcard_.{{SERVER_DOMAIN}}.key;

--- a/docker/nginx/conf.d.templates/server.skylink.conf
+++ b/docker/nginx/conf.d.templates/server.skylink.conf
@@ -25,8 +25,8 @@ server {
 server {
 	server_name *.{{SERVER_DOMAIN}}; # example: *.eu-ger-1.siasky.net
 
-	set $portal_domain "{{SERVER_DOMAIN}}"
-	set $server_domain "{{SERVER_DOMAIN}}"
+	set $portal_domain "{{SERVER_DOMAIN}}";
+	set $server_domain "{{SERVER_DOMAIN}}";
 
 	include /etc/nginx/conf.d/server/server.http;
 

--- a/docker/nginx/conf.d/include/location-hns
+++ b/docker/nginx/conf.d/include/location-hns
@@ -80,8 +80,8 @@ proxy_pass https://127.0.0.1/$skylink$path$is_args$args;
 
 # in case siad returns location header, we need to replace the skylink with the domain name
 header_filter_by_lua_block {
-    ngx.header["Skynet-Portal-Api"] = os.getenv("SKYNET_PORTAL_API")
-    ngx.header["Skynet-Server-Api"] = os.getenv("SKYNET_SERVER_API")
+    ngx.header["Skynet-Portal-Api"] = ngx.var.scheme .. "://" .. ngx.var.portal_domain
+    ngx.header["Skynet-Server-Api"] = ngx.var.scheme .. "://" .. ngx.var.server_domain
 
     if ngx.header.location then
         -- match location redirect part after the skylink

--- a/docker/nginx/conf.d/include/location-skylink
+++ b/docker/nginx/conf.d/include/location-skylink
@@ -73,8 +73,8 @@ access_by_lua_block {
 }
 
 header_filter_by_lua_block {
-    ngx.header["Skynet-Portal-Api"] = os.getenv("SKYNET_PORTAL_API")
-    ngx.header["Skynet-Server-Api"] = os.getenv("SKYNET_SERVER_API")
+    ngx.header["Skynet-Portal-Api"] = ngx.var.scheme .. "://" .. ngx.var.portal_domain
+    ngx.header["Skynet-Server-Api"] = ngx.var.scheme .. "://" .. ngx.var.server_domain
 
     -- not empty skynet_proof means this is a skylink v2 request
     -- so we should replace the Skynet-Proof header with the one

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -159,8 +159,7 @@ location /skynet/tus {
     proxy_set_header X-Forwarded-Proto $scheme;
 
     # rewrite proxy request to use correct host uri from env variable (required to return correct location header)
-    set_by_lua $SKYNET_SERVER_API 'return os.getenv("SKYNET_SERVER_API")';
-    proxy_redirect $scheme://$host $SKYNET_SERVER_API;
+    proxy_redirect $scheme://$host $scheme://$server_domain;
 
     # proxy /skynet/tus requests to siad endpoint with all arguments
     proxy_pass http://sia:9980;
@@ -192,8 +191,8 @@ location /skynet/tus {
 
     # extract skylink from base64 encoded upload metadata and assign to a proper header
     header_filter_by_lua_block {
-        ngx.header["Skynet-Portal-Api"] = os.getenv("SKYNET_PORTAL_API")
-        ngx.header["Skynet-Server-Api"] = os.getenv("SKYNET_SERVER_API")
+        ngx.header["Skynet-Portal-Api"] = ngx.var.scheme .. "://" .. ngx.var.portal_domain
+        ngx.header["Skynet-Server-Api"] = ngx.var.scheme .. "://" .. ngx.var.server_domain
 
         if ngx.header["Upload-Metadata"] then
             local encodedSkylink = string.match(ngx.header["Upload-Metadata"], "Skylink ([^,?]+)")
@@ -219,8 +218,8 @@ location /skynet/metadata {
     include /etc/nginx/conf.d/include/cors;
 
     header_filter_by_lua_block {
-        ngx.header["Skynet-Portal-Api"] = os.getenv("SKYNET_PORTAL_API")
-        ngx.header["Skynet-Server-Api"] = os.getenv("SKYNET_SERVER_API")
+        ngx.header["Skynet-Portal-Api"] = ngx.var.scheme .. "://" .. ngx.var.portal_domain
+        ngx.header["Skynet-Server-Api"] = ngx.var.scheme .. "://" .. ngx.var.server_domain
 
         -- do not expose internal header
         ngx.header["Skynet-Requested-Skylink"] = ""
@@ -234,8 +233,8 @@ location /skynet/resolve {
     include /etc/nginx/conf.d/include/cors;
 
     header_filter_by_lua_block {
-        ngx.header["Skynet-Portal-Api"] = os.getenv("SKYNET_PORTAL_API")
-        ngx.header["Skynet-Server-Api"] = os.getenv("SKYNET_SERVER_API")
+        ngx.header["Skynet-Portal-Api"] = ngx.var.scheme .. "://" .. ngx.var.portal_domain
+        ngx.header["Skynet-Server-Api"] = ngx.var.scheme .. "://" .. ngx.var.server_domain
 
         -- do not expose internal header
         ngx.header["Skynet-Requested-Skylink"] = ""

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -26,8 +26,6 @@ worker_processes auto;
 #pid        logs/nginx.pid;
 
 # declare env variables to use it in config
-env SKYNET_PORTAL_API;
-env SKYNET_SERVER_API;
 env ACCOUNTS_ENABLED;
 
 events {
@@ -78,8 +76,8 @@ http {
 
     # include skynet-portal-api and skynet-server-api header on every request
     header_filter_by_lua_block {
-        ngx.header["Skynet-Portal-Api"] = os.getenv("SKYNET_PORTAL_API")
-        ngx.header["Skynet-Server-Api"] = os.getenv("SKYNET_SERVER_API")
+        ngx.header["Skynet-Portal-Api"] = ngx.var.scheme .. "://" .. ngx.var.portal_domain
+        ngx.header["Skynet-Server-Api"] = ngx.var.scheme .. "://" .. ngx.var.server_domain
     }
 
     # ratelimit specified IPs

--- a/packages/dashboard/.env
+++ b/packages/dashboard/.env
@@ -1,4 +1,0 @@
-NEXT_PUBLIC_SKYNET_PORTAL_API=https://siasky.net
-NEXT_PUBLIC_SKYNET_DASHBOARD_URL=https://account.siasky.net
-NEXT_PUBLIC_KRATOS_BROWSER_URL=https://account.siasky.net/.ory/kratos/public
-NEXT_PUBLIC_KRATOS_PUBLIC_URL=https://account.siasky.net/.ory/kratos/public

--- a/packages/dashboard/src/components/Layout.js
+++ b/packages/dashboard/src/components/Layout.js
@@ -92,7 +92,7 @@ export default function Layout({ title, children }) {
                         </a>
                       </Link>
                       <a
-                        href={process.env.NEXT_PUBLIC_SKYNET_PORTAL_API}
+                        href={`https://${process.env.NEXT_PUBLIC_PORTAL_DOMAIN}`}
                         className="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium flex items-center"
                         target="_blank"
                         rel="noopener noreferrer"
@@ -244,8 +244,8 @@ export default function Layout({ title, children }) {
                 </a>
               </Link>
               <a
-                href={process.env.NEXT_PUBLIC_SKYNET_PORTAL_API}
-                className="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium flex items-center"
+                href={`https://${process.env.NEXT_PUBLIC_PORTAL_DOMAIN}`}
+                className="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-base font-medium flex items-center"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/packages/dashboard/src/config.js
+++ b/packages/dashboard/src/config.js
@@ -3,10 +3,10 @@ export default {
   kratos: {
     // The URL where ORY Kratos's Public API is located at. If this app and ORY Kratos are running in the same
     // private network, this should be the private network address (e.g. kratos-public.svc.cluster.local)
-    public: process.env.NEXT_PUBLIC_KRATOS_PUBLIC_URL.replace(/\/+$/, ""),
+    public: process.env.NEXT_PUBLIC_KRATOS_PUBLIC_URL,
     // The URL where ORY Kratos's public API is located, when accessible from the public internet via ORY Oathkeeper.
     // This could be for example http://kratos.my-app.com/.
-    browser: process.env.NEXT_PUBLIC_KRATOS_BROWSER_URL.replace(/\/+$/, ""),
+    browser: `https://account.${process.env.DOMAIN_NAME}/.ory/kratos/public`,
   },
   tiers: {
     starter: { id: "starter", tier: 1, name: "Free", description: "Pin up to 100GB" },

--- a/packages/dashboard/src/pages/api/stripe/billing.js
+++ b/packages/dashboard/src/pages/api/stripe/billing.js
@@ -18,7 +18,7 @@ export default async (req, res) => {
     const customer = await getStripeCustomer(stripeCustomerId);
     const session = await stripe.billingPortal.sessions.create({
       customer: customer.id,
-      return_url: `${process.env.SKYNET_DASHBOARD_URL}/payments`,
+      return_url: `https://account.${process.env.PORTAL_DOMAIN}/payments`,
     });
 
     res.redirect(session.url);

--- a/packages/dashboard/src/pages/api/stripe/checkout.js
+++ b/packages/dashboard/src/pages/api/stripe/checkout.js
@@ -47,8 +47,8 @@ export default async (req, res) => {
       customer: customer.id,
       client_reference_id: user.sub,
       allow_promotion_codes: true,
-      success_url: `${process.env.SKYNET_DASHBOARD_URL}/payments?session_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${process.env.SKYNET_DASHBOARD_URL}/payments`,
+      success_url: `https://account.${process.env.PORTAL_DOMAIN}/payments?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `https://account.${process.env.PORTAL_DOMAIN}/payments`,
     });
 
     res.json({ sessionId: session.id });

--- a/packages/dashboard/src/pages/downloads.js
+++ b/packages/dashboard/src/pages/downloads.js
@@ -7,7 +7,7 @@ import authServerSideProps from "../services/authServerSideProps";
 import { SkynetClient } from "skynet-js";
 import useAccountsApi from "../services/useAccountsApi";
 
-const skynetClient = new SkynetClient(process.env.NEXT_PUBLIC_SKYNET_PORTAL_API);
+const skynetClient = new SkynetClient(`https://${process.env.NEXT_PUBLIC_PORTAL_DOMAIN}`);
 const apiPrefix = process.env.NODE_ENV === "development" ? "/api/stubs" : "";
 const getSkylinkLink = ({ skylink }) => skynetClient.getSkylinkUrl(skylink);
 const getRelativeDate = ({ downloadedOn }) => dayjs(downloadedOn).format("YYYY-MM-DD HH:mm:ss");

--- a/packages/dashboard/src/pages/index.js
+++ b/packages/dashboard/src/pages/index.js
@@ -12,7 +12,7 @@ import { write } from "clipboardy";
 
 dayjs.extend(relativeTime);
 
-const skynetClient = new SkynetClient(process.env.NEXT_PUBLIC_SKYNET_PORTAL_API);
+const skynetClient = new SkynetClient(`https://${process.env.NEXT_PUBLIC_PORTAL_DOMAIN}`);
 const apiPrefix = process.env.NODE_ENV === "development" ? "/api/stubs" : "";
 
 export const getServerSideProps = authServerSideProps(async (context, api) => {

--- a/packages/dashboard/src/pages/uploads.js
+++ b/packages/dashboard/src/pages/uploads.js
@@ -7,7 +7,7 @@ import authServerSideProps from "../services/authServerSideProps";
 import { SkynetClient } from "skynet-js";
 import useAccountsApi from "../services/useAccountsApi";
 
-const skynetClient = new SkynetClient(process.env.NEXT_PUBLIC_SKYNET_PORTAL_API);
+const skynetClient = new SkynetClient(`https://${process.env.PORTAL_DOMAIN}`);
 const apiPrefix = process.env.NODE_ENV === "development" ? "/api/stubs" : "";
 const getSkylinkLink = ({ skylink }) => skynetClient.getSkylinkUrl(skylink);
 const getRelativeDate = ({ uploadedOn }) => dayjs(uploadedOn).format("YYYY-MM-DD HH:mm:ss");

--- a/packages/health-check/bin/cli
+++ b/packages/health-check/bin/cli
@@ -36,9 +36,9 @@ require("yargs/yargs")(process.argv.slice(2))
           type: "string",
           choices: ["critical", "extended"],
         })
-        .option("portal-url", {
-          describe: "Skynet portal url",
-          default: process.env.SKYNET_PORTAL_API || "https://siasky.net",
+        .option("portal-domain", {
+          describe: "Skynet portal domain (without schema)",
+          default: process.env.PORTAL_DOMAIN || "siasky.net",
           type: "string",
         })
         .option("state-dir", {
@@ -47,8 +47,8 @@ require("yargs/yargs")(process.argv.slice(2))
           type: "string",
         });
     },
-    async ({ type, portalUrl, stateDir }) => {
-      process.env.SKYNET_PORTAL_API = portalUrl;
+    async ({ type, portalDomain, stateDir }) => {
+      process.env.PORTAL_DOMAIN = portalDomain;
       process.env.STATE_DIR = stateDir;
 
       const util = require("util");

--- a/packages/health-check/src/checks/extended.js
+++ b/packages/health-check/src/checks/extended.js
@@ -1134,7 +1134,7 @@ async function skylinkVerification(done, expected, { followRedirect = true, meth
   const details = { name: expected.name, skylink: expected.skylink };
 
   try {
-    const query = `${process.env.SKYNET_PORTAL_API}/${expected.skylink}`;
+    const query = `https://${process.env.PORTAL_DOMAIN}/${expected.skylink}`;
     const response = await got[method](query, { followRedirect, headers: { cookie: "nocache=true" } });
     const entry = { ...details, up: true, statusCode: response.statusCode, time: calculateElapsedTime(time) };
     const info = {};
@@ -1170,7 +1170,7 @@ async function skylinkVerification(done, expected, { followRedirect = true, meth
 
     if (expected.metadata && expected.skylink) {
       const skylink = parseSkylink(expected.skylink);
-      const url = `${process.env.SKYNET_PORTAL_API}/skynet/metadata/${skylink}`;
+      const url = `https://${process.env.PORTAL_DOMAIN}/skynet/metadata/${skylink}`;
       try {
         const metadata = await got(url).json();
         if (!isEqual(expected.metadata, metadata)) {

--- a/packages/health-check/src/index.js
+++ b/packages/health-check/src/index.js
@@ -1,11 +1,7 @@
 process.env.NODE_ENV = process.env.NODE_ENV || "development";
 
-if (!process.env.SKYNET_PORTAL_API) {
-  throw new Error("You need to provide SKYNET_PORTAL_API environment variable");
-}
-
-if (process.env.ACCOUNTS_ENABLED === "true" && !process.env.SKYNET_DASHBOARD_URL) {
-  throw new Error("You need to provide SKYNET_DASHBOARD_URL environment variable when accounts are enabled");
+if (!process.env.PORTAL_DOMAIN) {
+  throw new Error("You need to provide PORTAL_DOMAIN environment variable (ie. siasky.net)");
 }
 
 const express = require("express");

--- a/setup-scripts/README.md
+++ b/setup-scripts/README.md
@@ -92,7 +92,6 @@ At this point we have almost everything running, we just need to set up your wal
    - `CLOUDFLARE_AUTH_TOKEN` (optional) if using cloudflare as dns loadbalancer (need to change it in Caddyfile too)
    - `AWS_ACCESS_KEY_ID` (optional) if using route53 as a dns loadbalancer
    - `AWS_SECRET_ACCESS_KEY` (optional) if using route53 as a dns loadbalancer
-   - `PORTAL_NAME` a string representing name of your portal e.g. `siasky.xyz` or `my skynet portal`
    - `DISCORD_WEBHOOK_URL` (required if using Discord notifications) discord webhook url (generate from discord app)
    - `DISCORD_MENTION_USER_ID` (optional) add `/cc @user` mention to important messages from webhook (has to be id not user name)
    - `DISCORD_MENTION_ROLE_ID` (optional) add `/cc @role` mention to important messages from webhook (has to be id not role name)

--- a/setup-scripts/README.md
+++ b/setup-scripts/README.md
@@ -86,10 +86,8 @@ At this point we have almost everything running, we just need to set up your wal
 
    - `PORTAL_DOMAIN` (required) is a skynet portal domain (ex. siasky.net)
    - `SERVER_DOMAIN` (optional) is an optional direct server domain (ex. eu-ger-1.siasky.net) - leave blank unless it is different than PORTAL_DOMAIN
-   - `EMAIL_ADDRESS` is your email address used for communication regarding SSL certification (required if you're using http-01 challenge)
    - `SIA_WALLET_PASSWORD` is your wallet password (or seed if you did not set a password)
    - `HSD_API_KEY` this is a random security key for a handshake integration that gets generated automatically
-   - `CLOUDFLARE_AUTH_TOKEN` (optional) if using cloudflare as dns loadbalancer (need to change it in Caddyfile too)
    - `AWS_ACCESS_KEY_ID` (optional) if using route53 as a dns loadbalancer
    - `AWS_SECRET_ACCESS_KEY` (optional) if using route53 as a dns loadbalancer
    - `DISCORD_WEBHOOK_URL` (required if using Discord notifications) discord webhook url (generate from discord app)

--- a/setup-scripts/bot_utils.py
+++ b/setup-scripts/bot_utils.py
@@ -64,8 +64,9 @@ async def send_msg(msg, force_notify=False, file=None):
         webhook_mention_role_id = os.getenv("DISCORD_MENTION_ROLE_ID")
         webhook = DiscordWebhook(url=webhook_url, rate_limit_retry=True)
 
-        # Add the portal name.
-        msg = "**{}**: {}".format(os.getenv("SKYNET_SERVER_API"), msg)
+        # prefix message with the server name
+        server_name = os.getenv("SERVER_DOMAIN") or os.getenv("PORTAL_DOMAIN") or "n/a"
+        msg = "**{}**: {}".format(server_name, msg)
 
         if file and isinstance(file, str):
             is_json = is_json_string(file)

--- a/setup-scripts/setup-docker-services.sh
+++ b/setup-scripts/setup-docker-services.sh
@@ -23,12 +23,7 @@ docker-compose --version # sanity check
 # Create dummy .env file for docker-compose usage with variables
 # * PORTAL_DOMAIN - (required) is a skynet portal domain (ex. siasky.net)
 # * SERVER_DOMAIN - (optional) is an optional direct server domain (ex. eu-ger-1.siasky.net) - leave blank unless it is different than PORTAL_DOMAIN
-# * SKYNET_PORTAL_API - absolute url to the portal api ie. https://siasky.net (general portal address)
-# * SKYNET_SERVER_API - absolute url to the server api ie. https://eu-ger-1.siasky.net (direct server address, if this is single server portal use the same address as SKYNET_PORTAL_API)
-# * SKYNET_DASHBOARD_URL - (optional) absolute url to the portal dashboard ie. https://account.siasky.net
-# * EMAIL_ADDRESS - this is the administrator contact email you need to supply for communication regarding SSL certification
 # * HSD_API_KEY - this is auto generated secure key for your handshake service integration
-# * CLOUDFLARE_AUTH_TOKEN - (optional) if using cloudflare as dns loadbalancer (need to change it in Caddyfile too)
 # * AWS_ACCESS_KEY_ID - (optional) if using route53 as a dns loadbalancer
 # * AWS_SECRET_ACCESS_KEY - (optional) if using route53 as a dns loadbalancer
 # * API_PORT - (optional) the port on which siad is listening, defaults to 9980
@@ -46,7 +41,7 @@ docker-compose --version # sanity check
 # * CR_CLUSTER_NODES - (optional) if using `accounts` the list of servers (with ports) which make up your CockroachDB cluster, e.g. `helsinki.siasky.net:26257,germany.siasky.net:26257,us-east.siasky.net:26257`
 if ! [ -f /home/user/skynet-webportal/.env ]; then
     HSD_API_KEY=$(openssl rand -base64 32) # generate safe random key for handshake
-    printf "PORTAL_DOMAIN=siasky.net\nSERVER_DOMAIN=\nSKYNET_PORTAL_API=https://siasky.net\nSKYNET_SERVER_API=https://eu-dc-1.siasky.net\nSKYNET_DASHBOARD_URL=https://account.example.com\nEMAIL_ADDRESS=email@example.com\nSIA_WALLET_PASSWORD=\nHSD_API_KEY=${HSD_API_KEY}\nCLOUDFLARE_AUTH_TOKEN=\nAWS_ACCESS_KEY_ID=\nAWS_SECRET_ACCESS_KEY=\nDISCORD_WEBHOOK_URL=\nDISCORD_MENTION_USER_ID=\nDISCORD_MENTION_ROLE_ID=\n" > /home/user/skynet-webportal/.env
+    printf "PORTAL_DOMAIN=siasky.net\nSERVER_DOMAIN=\nSIA_WALLET_PASSWORD=\nHSD_API_KEY=${HSD_API_KEY}\nAWS_ACCESS_KEY_ID=\nAWS_SECRET_ACCESS_KEY=\nDISCORD_WEBHOOK_URL=\nDISCORD_MENTION_USER_ID=\nDISCORD_MENTION_ROLE_ID=\n" > /home/user/skynet-webportal/.env
 fi
 
 # Start docker container with nginx and client

--- a/setup-scripts/setup-docker-services.sh
+++ b/setup-scripts/setup-docker-services.sh
@@ -32,7 +32,6 @@ docker-compose --version # sanity check
 # * AWS_ACCESS_KEY_ID - (optional) if using route53 as a dns loadbalancer
 # * AWS_SECRET_ACCESS_KEY - (optional) if using route53 as a dns loadbalancer
 # * API_PORT - (optional) the port on which siad is listening, defaults to 9980
-# * PORTAL_NAME - a string representing name of your portal e.g. `siasky.xyz` or `my skynet portal` (internal use only)
 # * DISCORD_WEBHOOK_URL - (required if using Discord notifications) discord webhook url (generate from discord app)
 # * DISCORD_MENTION_USER_ID - (optional) add `/cc @user` mention to important messages from webhook (has to be id not user name)
 # * DISCORD_MENTION_ROLE_ID - (optional) add `/cc @role` mention to important messages from webhook (has to be id not role name)
@@ -47,7 +46,7 @@ docker-compose --version # sanity check
 # * CR_CLUSTER_NODES - (optional) if using `accounts` the list of servers (with ports) which make up your CockroachDB cluster, e.g. `helsinki.siasky.net:26257,germany.siasky.net:26257,us-east.siasky.net:26257`
 if ! [ -f /home/user/skynet-webportal/.env ]; then
     HSD_API_KEY=$(openssl rand -base64 32) # generate safe random key for handshake
-    printf "PORTAL_DOMAIN=siasky.net\nSERVER_DOMAIN=\nSKYNET_PORTAL_API=https://siasky.net\nSKYNET_SERVER_API=https://eu-dc-1.siasky.net\nSKYNET_DASHBOARD_URL=https://account.example.com\nEMAIL_ADDRESS=email@example.com\nSIA_WALLET_PASSWORD=\nHSD_API_KEY=${HSD_API_KEY}\nCLOUDFLARE_AUTH_TOKEN=\nAWS_ACCESS_KEY_ID=\nAWS_SECRET_ACCESS_KEY=\nPORTAL_NAME=\DISCORD_WEBHOOK_URL=\nDISCORD_MENTION_USER_ID=\nDISCORD_MENTION_ROLE_ID=\n" > /home/user/skynet-webportal/.env
+    printf "PORTAL_DOMAIN=siasky.net\nSERVER_DOMAIN=\nSKYNET_PORTAL_API=https://siasky.net\nSKYNET_SERVER_API=https://eu-dc-1.siasky.net\nSKYNET_DASHBOARD_URL=https://account.example.com\nEMAIL_ADDRESS=email@example.com\nSIA_WALLET_PASSWORD=\nHSD_API_KEY=${HSD_API_KEY}\nCLOUDFLARE_AUTH_TOKEN=\nAWS_ACCESS_KEY_ID=\nAWS_SECRET_ACCESS_KEY=\nDISCORD_WEBHOOK_URL=\nDISCORD_MENTION_USER_ID=\nDISCORD_MENTION_ROLE_ID=\n" > /home/user/skynet-webportal/.env
 fi
 
 # Start docker container with nginx and client

--- a/setup-scripts/support/sia.env
+++ b/setup-scripts/support/sia.env
@@ -6,7 +6,6 @@ SIA_WALLET_PASSWORD=""
 
 # portal specific environment variables
 API_PORT="9980"
-PORTAL_NAME=""
 
 # discord integration
 DISCORD_WEBHOOK_URL=""


### PR DESCRIPTION
part of the work for https://github.com/SkynetLabs/skynet-webportal/issues/718

- `SKYNET_PORTAL_API` removed - we can deduct that address from `PORTAL_DOMAIN`
- `SKYNET_SERVER_API` removed - we can deduct that address from `SERVER_DOMAIN`
- `SKYNET_DASHBOARD_URL` removed - we can construct the url with `PORTAL_DOMAIN` - this is always `https://account.<portal_domain>`, prefix is not configurable
- `JAEGER_SERVICE_NAME` removed - apparently not used
- expose `portal_domain` and `server_domain` global variables to nginx configuration
  - `server_domain` equals `portal_domain` if server_domain is not set
  - `portal_domain` equals `server_domain` if the request was done directly through `server_domain`
- `packages/dashboard/.env` file removed - I think this was included there by mistake, it's not used