### PR TITLE
fixed issue with caddy requesting new certificates

### DIFF
--- a/changelog/items/bugs-fixed/fix-caddy.md
+++ b/changelog/items/bugs-fixed/fix-caddy.md
@@ -1,0 +1,1 @@
+- fixed issue with caddy requesting new certificates instead of using existing ones from file storage

--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -3,7 +3,7 @@ FROM caddy:2.4.5-builder AS caddy-builder
 # available dns resolvers: https://github.com/caddy-dns
 RUN xcaddy build --with github.com/caddy-dns/route53
 
-FROM caddy:2.4.5-builder
+FROM caddy:2.4.5-alpine
 
 COPY --from=caddy-builder /usr/bin/caddy /usr/bin/caddy
 

--- a/docker/caddy/caddy.json.template
+++ b/docker/caddy/caddy.json.template
@@ -20,11 +20,11 @@
             "issuers": [
               {
                 "module": "acme",
+                "email": "{{EMAIL_ADDRESS}}",
                 "challenges": {
                   "dns": {
                     "provider": {
-                      "name": "route53",
-                      "max_retries": 100
+                      "name": "route53"
                     }
                   }
                 }


### PR DESCRIPTION
When https://github.com/SkynetLabs/skynet-webportal/commit/e42dfacfdb37e18089f52e8da735fab1c1801e18 was merged, I didn't notice that it also set the `caddy:2.4.5` image to `caddy:2.4.5-builder`. Since `caddy:2.4.5` was a shortcut to `caddy:2.4.5-alpine` and `caddy:2.4.5-builder` is not an alpine container, there was a mismatch in the directory where caddy stored it's config data and certificates - for `caddy:2.4.5-builder` it turned out to be `/root/.config` and `/root/.local/share` instead of `/config` and `/data` respectively. Out docker setup mounted `/config` and `/data` and expected them to be valid paths, while caddy looked for data in the other directories and since it didn't find them, it requested completely new set of certificates. Due to that fact we ran out of limits on letsencrypt because each server tried to fetch new certificates.

- changed `caddy:2.4.5-builder` to `caddy:2.4.5-alpine` (added `alpine` suffix explicitly so next time dependabot knows what image this is)
- removed `max_retries` - those should be set to default which is no limit
- added `email` because according to documentation we could potentially benefit from exposing our dev email to certificate authority - they may want to contact us in some cases