### PR TITLE
fixed the latest news link redirect in the news header

### DIFF
--- a/changelog/items/bugs-fixed/fix-external-links-on-news-header.md
+++ b/changelog/items/bugs-fixed/fix-external-links-on-news-header.md
@@ -1,0 +1,1 @@
+- fixed the latest news link redirect in the news header

--- a/packages/website/src/components/NewsHeader/NewsHeader.js
+++ b/packages/website/src/components/NewsHeader/NewsHeader.js
@@ -12,6 +12,7 @@ const NewsHeader = () => {
             id
             frontmatter {
               title
+              external
             }
             fields {
               slug
@@ -26,8 +27,9 @@ const NewsHeader = () => {
 
   if (!latestNews) return null; // no news
 
-  const title = latestNews.node.frontmatter.title;
-  const link = { to: latestNews.node.fields.slug };
+  const { frontmatter, fields } = latestNews.node;
+  const { title, external } = frontmatter;
+  const link = external ? { href: external } : { to: fields.slug };
 
   return (
     <div className="bg-palette-500 px-8 p-3">

--- a/packages/website/src/pages/news.js
+++ b/packages/website/src/pages/news.js
@@ -6,39 +6,36 @@ import { NewsSummary } from "../components/News";
 import Link from "../components/Link";
 import Seo from "../components/seo";
 
-const NewsCard = ({ ...props }) => {
-  const linkProps = { to: !props.frontmatter.external && props.fields.slug, href: props.frontmatter.external };
+const NewsCard = ({ frontmatter, fields }) => {
+  const { title, external, categories, description, thumbnail, avatar, author, date } = frontmatter;
+  const link = external ? { href: external } : { to: fields.slug };
 
   return (
     <div className="flex flex-col">
-      <Link {...linkProps} className="flex items-center">
-        <GatsbyImage image={getImage(props.frontmatter.thumbnail)} alt={props.frontmatter.title} />
+      <Link {...link} className="flex items-center">
+        <GatsbyImage image={getImage(thumbnail)} alt={title} />
       </Link>
 
-      {props.frontmatter.categories && (
+      {categories && (
         <div className="mt-6">
-          {props.frontmatter.categories.map((category) => (
+          {categories.map((category) => (
             <Label key={category}>{category}</Label>
           ))}
         </div>
       )}
 
-      <Link {...linkProps} className="text-xl mt-6">
-        {props.frontmatter.title}
+      <Link {...link} className="text-xl mt-6">
+        {title}
       </Link>
 
-      {props.frontmatter.description && (
-        <Link {...linkProps} className="font-content text-palette-400 mt-4">
-          {props.frontmatter.description}
+      {description && (
+        <Link {...link} className="font-content text-palette-400 mt-4">
+          {description}
         </Link>
       )}
 
       <div className="mt-6">
-        <NewsSummary
-          avatar={props.frontmatter.avatar}
-          author={props.frontmatter.author}
-          date={props.frontmatter.date}
-        />
+        <NewsSummary avatar={avatar} author={author} date={date} />
       </div>
     </div>
   );


### PR DESCRIPTION
news header link on the https://siasky.net/ webpage routes to https://siasky.net/news/announcing-homescreen/ while it should route to external medium article https://blog.sia.tech/announcing-homescreen-decentralized-frontends-for-web3-113a3564530d

while doing that I also cleaned up some code on news page that was responsible for the same thing just to make things more explicit and clear