### PR TITLE
Backup MongoDB before CockroachDB

### DIFF
--- a/scripts/db_backup.sh
+++ b/scripts/db_backup.sh
@@ -27,26 +27,6 @@ fi
 # Take the current datetime:
 DT=$(date +%Y-%m-%d)
 
-### COCKROACH DB ###
-echo "Creating a backup of CockroachDB:"
-# Check if a backup already exists:
-totalFoundObjects=$(aws s3 ls $S3_BACKUP_PATH/$DT --recursive --summarize | grep "cockroach" | wc -l)
-if [ "$totalFoundObjects" -ge "1" ]; then
-  echo "Backup already exists for today. Skipping."
-else
-  # Create a cockroachdb backup:
-  docker exec cockroach \
-    cockroach sql \
-    --host cockroach:26257 \
-    --certs-dir=/certs \
-    --execute="BACKUP TO '$S3_BACKUP_PATH/$DT/cockroach/?AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID&AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY';"
-  if [[ $? > 0 ]]; then
-    echo "Creating a CockroachDB backup failed. Skipping."
-  else
-    echo "Successfully backed up CockroachDB."
-  fi
-fi
-
 ### MONGO DB ###
 echo "Creating a backup of MongoDB:"
 # Check if a backup already exists:
@@ -72,4 +52,24 @@ else
     echo "Finished MongoDB backup."
   fi
   docker exec mongo rm -rf /data/db/backups/$DT
+fi
+
+### COCKROACH DB ###
+echo "Creating a backup of CockroachDB:"
+# Check if a backup already exists:
+totalFoundObjects=$(aws s3 ls $S3_BACKUP_PATH/$DT --recursive --summarize | grep "cockroach" | wc -l)
+if [ "$totalFoundObjects" -ge "1" ]; then
+  echo "Backup already exists for today. Skipping."
+else
+  # Create a cockroachdb backup:
+  docker exec cockroach \
+    cockroach sql \
+    --host cockroach:26257 \
+    --certs-dir=/certs \
+    --execute="BACKUP TO '$S3_BACKUP_PATH/$DT/cockroach/?AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID&AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY';"
+  if [[ $? > 0 ]]; then
+    echo "Creating a CockroachDB backup failed. Skipping."
+  else
+    echo "Successfully backed up CockroachDB."
+  fi
 fi


### PR DESCRIPTION
# PULL REQUEST

## Overview

Change the order of backup creation.  

The issue is that if a user registers while we're creating those backups, they might register exactly after we've created the first backup and before we've created the second one. This might lead to the user existing in only one of the two databases.
If the user exists in Cockroach but not in Mongo, we don't have an issue at all - `accounts` was built with this setup in mind and it will backfill the user's information in Mongo using data coming from Cockroach (via the JWT token) and from Stripe (via the webhook).
If, on the other hand, the user only exists in Mongo then when we restore there will be no way to backfill their data in Cockroach. Moreover, should they try to register again, that will result in an error in `accounts` because their email address would appear to be used by an account with a different `sub` than the one coming from Cockroach, so we won't be able to create such an account. 

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
