### PR TITLE
Increase the request body size of the /skynet/restore endpoint to 5MB.

### DIFF
--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -114,6 +114,7 @@ location /skynet/registry {
 
 location /skynet/restore {
     include /etc/nginx/conf.d/include/cors;
+    include /etc/nginx/conf.d/include/sia-auth;
 
     client_max_body_size 5M;
 }

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -114,12 +114,11 @@ location /skynet/registry {
 
 location /skynet/restore {
     include /etc/nginx/conf.d/include/cors;
-    include /etc/nginx/conf.d/include/sia-auth;
 
     client_max_body_size 5M;
 
     proxy_set_header User-Agent: Sia-Agent;
-    proxy_pass http://sia:9980/skynet/restore;
+    proxy_pass http://sia:9980;
 }
 
 location /skynet/skyfile {

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -115,7 +115,6 @@ location /skynet/registry {
 location /skynet/restore {
     include /etc/nginx/conf.d/include/cors;
     include /etc/nginx/conf.d/include/sia-auth;
-    include /etc/nginx/conf.d/include/generate-siapath;
 
     client_max_body_size 5M;
 
@@ -128,7 +127,7 @@ location /skynet/restore {
     proxy_set_header User-Agent: Sia-Agent;
 
     # proxy this call to siad endpoint (make sure the ip is correct)
-    proxy_pass http://sia:9980/skynet/restore/$dir1/$dir2/$dir3$is_args$args;
+    proxy_pass http://sia:9980;
 }
 
 location /skynet/skyfile {

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -114,6 +114,7 @@ location /skynet/registry {
 
 location /skynet/restore {
     include /etc/nginx/conf.d/include/cors;
+    include /etc/nginx/conf.d/include/sia-auth;
 
     client_max_body_size 5M;
 

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -117,6 +117,9 @@ location /skynet/restore {
     include /etc/nginx/conf.d/include/sia-auth;
 
     client_max_body_size 5M;
+
+    proxy_set_header User-Agent: Sia-Agent;
+    proxy_pass http://sia:9980/skynet/restore;
 }
 
 location /skynet/skyfile {

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -115,11 +115,20 @@ location /skynet/registry {
 location /skynet/restore {
     include /etc/nginx/conf.d/include/cors;
     include /etc/nginx/conf.d/include/sia-auth;
+    include /etc/nginx/conf.d/include/generate-siapath;
 
     client_max_body_size 5M;
 
+    # increase request timeouts
+    proxy_read_timeout 600;
+    proxy_send_timeout 600;
+
+    proxy_request_buffering off; # stream uploaded files through the proxy as it comes in
+    proxy_set_header Expect $http_expect;
     proxy_set_header User-Agent: Sia-Agent;
-    proxy_pass http://sia:9980;
+
+    # proxy this call to siad endpoint (make sure the ip is correct)
+    proxy_pass http://sia:9980/skynet/restore/$dir1/$dir2/$dir3$is_args$args;
 }
 
 location /skynet/skyfile {

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -113,6 +113,8 @@ location /skynet/registry {
 }
 
 location /skynet/restore {
+    include /etc/nginx/conf.d/include/cors;
+
     client_max_body_size 5M;
 }
 

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -112,6 +112,10 @@ location /skynet/registry {
     include /etc/nginx/conf.d/include/location-skynet-registry;
 }
 
+location /skynet/restore {
+    client_max_body_size 5M;
+}
+
 location /skynet/skyfile {
     include /etc/nginx/conf.d/include/cors;
     include /etc/nginx/conf.d/include/sia-auth;
@@ -158,8 +162,8 @@ location /skynet/tus {
 
     # TUS chunks size is 40M + leaving 10M of breathing room
     client_max_body_size 50M;
-    
-    # Those timeouts need to be elevated since skyd can stall reading 
+
+    # Those timeouts need to be elevated since skyd can stall reading
     # data for a while when overloaded which would terminate connection
     client_body_timeout 1h;
     proxy_send_timeout  1h;
@@ -234,7 +238,7 @@ location /skynet/metadata {
 
         -- do not expose internal header
         ngx.header["Skynet-Requested-Skylink"] = ""
-    }    
+    }
 
     proxy_set_header User-Agent: Sia-Agent;
     proxy_pass http://sia:9980;
@@ -249,7 +253,7 @@ location /skynet/resolve {
 
         -- do not expose internal header
         ngx.header["Skynet-Requested-Skylink"] = ""
-    }    
+    }
 
     proxy_set_header User-Agent: Sia-Agent;
     proxy_pass http://sia:9980;


### PR DESCRIPTION
# PULL REQUEST

## Overview

Increase the request body size of the /skynet/restore endpoint to 5MB.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
