### PR TITLE
fix undefined dir upload name and empty progress

### DIFF
--- a/changelog/items/bugs-fixed/undefined-dir-upload-name-and-empty-progress.md
+++ b/changelog/items/bugs-fixed/undefined-dir-upload-name-and-empty-progress.md
@@ -1,0 +1,2 @@
+- fixed uploaded directory name (was "undefined" before)
+- fixed empty directory upload progress (size was not calculated for directories)

--- a/packages/website/src/components/Uploader/Uploader.js
+++ b/packages/website/src/components/Uploader/Uploader.js
@@ -47,8 +47,9 @@ const Uploader = () => {
   const handleDrop = async (files) => {
     if (mode === "directory" && files.length) {
       const name = getRootDirectory(files[0]); // get the file path from the first file
+      const size = files.reduce((acc, file) => acc + file.size, 0);
 
-      files = [{ name, files }];
+      files = [{ name, size, files }];
     }
 
     setUploads((uploads) => [...files.map((file) => ({ id: nanoid(), file, mode, status: "enqueued" })), ...uploads]);

--- a/packages/website/src/components/Uploader/UploaderElement.js
+++ b/packages/website/src/components/Uploader/UploaderElement.js
@@ -85,7 +85,7 @@ export default function UploaderElement({ onUploadStateChange, upload }) {
           if (upload.mode === "directory") {
             const files = upload.file.files;
             const directory = files.reduce((acc, file) => ({ ...acc, [getRelativeFilePath(file)]: file }), {});
-            const name = encodeURIComponent(upload.name);
+            const name = encodeURIComponent(upload.file.name);
 
             response = await client.uploadDirectory(directory, name, { onUploadProgress });
           } else {


### PR DESCRIPTION
# PULL REQUEST

## Overview

- fixed uploaded directory name (was "undefined" before)
- fixed empty directory upload progress (size was not calculated for directories)

## Example for Visual Changes

### Uploaded directory name fix

Before:
<img width="609" alt="Screenshot 2021-11-04 at 14 34 51" src="https://user-images.githubusercontent.com/3755029/140322769-a5b2dca6-d48e-4a19-8eea-60717d38e70f.png">

After:
<img width="637" alt="Screenshot 2021-11-04 at 14 34 13" src="https://user-images.githubusercontent.com/3755029/140322807-3791067c-be00-477a-9de3-465eb86274e8.png">

### Directory upload progress fix

Before:<img width="834" alt="Screenshot 2021-11-04 at 14 26 03" src="https://user-images.githubusercontent.com/3755029/140321570-d6010665-1cd3-47f2-b742-4d6f103cd71a.png">

After:
<img width="834" alt="Screenshot 2021-11-04 at 14 25 16" src="https://user-images.githubusercontent.com/3755029/140321590-b69dc0bb-63b7-4dc5-a42c-7c5ed81982e3.png">

## Issues Closed

closes #1347 
