### PR TITLE
Remove Airtable hardcoded default values

### DIFF
--- a/changelog/items/other/airtable-env-vars.md
+++ b/changelog/items/other/airtable-env-vars.md
@@ -1,0 +1,2 @@
+- Remove hardcoded Airtable default values from blocklist script. Portal
+  operators need to define their own values in portal common config (LastPass).

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -15,16 +15,15 @@ import json
 setup()
 
 
-# Check and load Airtable environment variables
-airtable_env_vars = ["AIRTABLE_API_KEY", "AIRTABLE_BASE", "AIRTABLE_TABLE", "AIRTABLE_FIELD"]
+AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+AIRTABLE_BASE = os.getenv("AIRTABLE_BASE")
+AIRTABLE_TABLE = os.getenv("AIRTABLE_TABLE")
+AIRTABLE_FIELD = os.getenv("AIRTABLE_FIELD")
 
-for e in airtable_env_vars:
-    # Check environment variable is defined
-    gete = os.getenv(e)
-    if not gete:
-        sys.exit("Configuration error: Environment variable " + e + " is not defined")
-    # Set variable
-    exec(e + " = \"" + gete + "\"")
+# Check environment variables are defined
+for e in [AIRTABLE_API_KEY, AIRTABLE_BASE, AIRTABLE_TABLE, AIRTABLE_FIELD]
+    if not e:
+        sys.exit("Configuration error: Missing AirTable environment variable.")
 
 
 async def run_checks():

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -6,6 +6,7 @@ from time import sleep
 
 import traceback
 import os
+import sys
 import re
 import asyncio
 import requests
@@ -13,10 +14,17 @@ import json
 
 setup()
 
-AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
-AIRTABLE_BASE = os.getenv("AIRTABLE_BASE")
-AIRTABLE_TABLE = os.getenv("AIRTABLE_TABLE")
-AIRTABLE_FIELD = os.getenv("AIRTABLE_FIELD")
+
+# Check and load Airtable environment variables
+airtable_env_vars = ["AIRTABLE_API_KEY", "AIRTABLE_BASE", "AIRTABLE_TABLE", "AIRTABLE_FIELD"]
+
+for e in airtable_env_vars:
+    # Check environment variable is defined
+    gete = os.getenv(e)
+    if not gete:
+        sys.exit("Configuration error: Environment variable " + e + " is not defined")
+    # Set variable
+    exec(e + " = \"" +gete + "\"")
 
 
 async def run_checks():

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -24,7 +24,7 @@ for e in airtable_env_vars:
     if not gete:
         sys.exit("Configuration error: Environment variable " + e + " is not defined")
     # Set variable
-    exec(e + " = \"" +gete + "\"")
+    exec(e + " = \"" + gete + "\"")
 
 
 async def run_checks():

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -14,9 +14,9 @@ import json
 setup()
 
 AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
-AIRTABLE_BASE = os.getenv("AIRTABLE_BASE", "app89plJvA9EqTJEc")
-AIRTABLE_TABLE = os.getenv("AIRTABLE_TABLE", "Table%201")
-AIRTABLE_FIELD = os.getenv("AIRTABLE_FIELD", "Link")
+AIRTABLE_BASE = os.getenv("AIRTABLE_BASE")
+AIRTABLE_TABLE = os.getenv("AIRTABLE_TABLE")
+AIRTABLE_FIELD = os.getenv("AIRTABLE_FIELD")
 
 
 async def run_checks():

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -21,7 +21,7 @@ AIRTABLE_TABLE = os.getenv("AIRTABLE_TABLE")
 AIRTABLE_FIELD = os.getenv("AIRTABLE_FIELD")
 
 # Check environment variables are defined
-for e in [AIRTABLE_API_KEY, AIRTABLE_BASE, AIRTABLE_TABLE, AIRTABLE_FIELD]
+for e in [AIRTABLE_API_KEY, AIRTABLE_BASE, AIRTABLE_TABLE, AIRTABLE_FIELD]:
     if not e:
         sys.exit("Configuration error: Missing AirTable environment variable.")
 


### PR DESCRIPTION
# PULL REQUEST

## Overview

Hardcoded default Airtable values were removed from blocklist script. They are defined in `.env` file which will be generated from common portal config (stored in LastPass or another choosen secure storage).

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->

#1367 