### PR TITLE
Nginx min_free

### DIFF
--- a/changelog/items/other/min-free-param.md
+++ b/changelog/items/other/min-free-param.md
@@ -1,0 +1,1 @@
+- Set `min_free` parameter on the `proxy_cache_path` directive to `100g`

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -70,7 +70,7 @@ http {
     proxy_http_version 1.1;
 
     # proxy cache definition
-    proxy_cache_path /data/nginx/cache levels=1:2 keys_zone=skynet:10m max_size=50g inactive=48h use_temp_path=off;
+    proxy_cache_path /data/nginx/cache levels=1:2 keys_zone=skynet:10m max_size=50g min_free=100g inactive=48h use_temp_path=off;
 
     # this runs before forking out nginx worker processes
     init_by_lua_block { 


### PR DESCRIPTION
# PULL REQUEST

## Overview

Since v1.19.1 Nginx supports a new parameter called `min_free` in the `proxy_cache_path` directive.

> The special “cache manager” process monitors the maximum cache size set by the max_size parameter, and the minimum amount of free space set by the min_free (1.19.1) parameter on the file system with cache. When the size is exceeded or there is not enough free space, it removes the least recently used data. The data is removed in iterations configured by manager_files, manager_threshold, and manager_sleep parameters (1.11.5). During one iteration no more than manager_files items are deleted (by default, 100). The duration of one iteration is limited by the manager_threshold parameter (by default, 200 milliseconds). Between iterations, a pause configured by the manager_sleep parameter (by default, 50 milliseconds) is made.

We want to set this on all of our production servers and set it to a reasonable value of 100g.
Link to docs: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_path

## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] Changelog file created

## Issues Closed
N/A
