### PR TITLE
Mute check failures unless server is down

### DIFF
--- a/setup-scripts/health-checker.py
+++ b/setup-scripts/health-checker.py
@@ -226,7 +226,8 @@ async def check_health():
         message += "{}/{} CRITICAL checks failed over the last {} hours! ".format(
             critical_checks_failed, critical_checks_total, CHECK_HOURS
         )
-        force_notify = True
+        # Disabling as it creates notification fatigue.
+        # force_notify = True
     else:
         message += "All {} critical checks passed. ".format(critical_checks_total)
 
@@ -234,7 +235,8 @@ async def check_health():
         message += "{}/{} extended checks failed over the last {} hours! ".format(
             extended_checks_failed, extended_checks_total, CHECK_HOURS
         )
-        force_notify = True
+        # Disabling as it creates notification fatigue.
+        # force_notify = True
     else:
         message += "All {} extended checks passed. ".format(extended_checks_total)
 


### PR DESCRIPTION
# PULL REQUEST

## Overview
Muting the ping for random checks failing, we should only be pinged if the server is down which means the failing checks were not a one-off fluke. 
