### PR TITLE
Hot reload nginx after pruning cache

### DIFF
--- a/changelog/items/other/nginx-prune-hot-reload.md
+++ b/changelog/items/other/nginx-prune-hot-reload.md
@@ -1,0 +1,1 @@
+- Hot reload Nginx after pruning cache files.

--- a/scripts/nginx-prune.sh
+++ b/scripts/nginx-prune.sh
@@ -2,5 +2,8 @@
 
 # We execute the nginx cache pruning subscript from docker container so that we
 # can run the pruning script in user crontab without sudo.
-
 docker run --rm -v /home/user:/home/user bash /home/user/skynet-webportal/scripts/lib/nginx-prune-cache-subscript.sh
+
+# Some cache files are deleted, but are kept open, we hot reload nginx to get
+# them closed and removed from filesystem.
+docker exec nginx nginx -s reload


### PR DESCRIPTION
# PULL REQUEST

## Overview

Some portals (`us-ny-1`, `us-ny-2`) are repeatedly disabled by health checker due to low disk space.
Disk usage dump shows difference (> 300GB) between `df`(includes deleted files) and `du` (doesn't include deleted files), which could be caused by deleted but still open files by nginx (and elastic).

This PR will try to compete deletion of files by nginx hot reload and releasing the files.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
