### PR TITLE
add accounts maintenance mode redirect

### DIFF
--- a/packages/dashboard/next.config.js
+++ b/packages/dashboard/next.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  async redirects() {
+    const redirects = [];
+
+    if (process.env.ACCOUNTS_MAINTENANCE === "true") {
+      redirects.push({
+        source: "/((?!maintenance$).*)",
+        destination: "/maintenance",
+        permanent: false,
+      });
+    }
+
+    return redirects;
+  },
+};


### PR DESCRIPTION
add accounts maintenance mode that is enabled by setting `ACCOUNTS_MAINTENANCE` env variable to `true`

dashboard redirects with 307 to /maintenance on every page request when maintenance mode is on