### PR TITLE
add proxy for stripe webhook endpoint

### DIFF
--- a/docker/nginx/conf.d/server/server.account
+++ b/docker/nginx/conf.d/server/server.account
@@ -12,6 +12,10 @@ location /health {
     proxy_pass http://accounts:3000;
 }
 
+location /stripe/webhook {
+    proxy_pass http://accounts:3000;
+}
+
 location /api/stripe/billing {
     proxy_pass http://dashboard:3000;
 }


### PR DESCRIPTION
adds proxy to accounts service for /stripe/webhook - this endpoint was missed during accounts dashboard migration