### PR TITLE
use portal modules env to discover services in nginx

### DIFF
--- a/docker/nginx/conf.d/include/location-skylink
+++ b/docker/nginx/conf.d/include/location-skylink
@@ -66,7 +66,7 @@ access_by_lua_block {
     end
 
     -- this block runs only when accounts are enabled
-    if os.getenv("ACCOUNTS_ENABLED") ~= "true" then return end
+    if not os.getenv("PORTAL_MODULES"):match("a") then return end
 
     -- 10.10.10.70 points to accounts service (alias not available when using resty-http)
     local res, err = httpc:request_uri("http://10.10.10.70:3000/user/limits", {

--- a/docker/nginx/conf.d/include/location-skynet-registry
+++ b/docker/nginx/conf.d/include/location-skynet-registry
@@ -11,7 +11,7 @@ proxy_pass http://sia:9980/skynet/registry;
 
 access_by_lua_block {
     -- this block runs only when accounts are enabled
-    if os.getenv("ACCOUNTS_ENABLED") ~= "true" then return end
+    if not os.getenv("PORTAL_MODULES"):match("a") then return end
 
     local httpc = require("resty.http").new()
 

--- a/docker/nginx/conf.d/include/track-download
+++ b/docker/nginx/conf.d/include/track-download
@@ -1,48 +1,51 @@
 # register the download in accounts service (cookies should contain jwt)
 log_by_lua_block {
     -- this block runs only when accounts are enabled
-    if os.getenv("ACCOUNTS_ENABLED") ~= "true" then return end
+    if os.getenv("PORTAL_MODULES"):match("a") then
+        local function track(premature, skylink, status, body_bytes_sent, jwt)
+            if premature then return end
 
-    local function track(premature, skylink, status, body_bytes_sent, jwt)
-        if premature then return end
+            local httpc = require("resty.http").new()
+            local query = table.concat({ "status=" .. status, "bytes=" .. body_bytes_sent }, "&")
 
-        local httpc = require("resty.http").new()
-        local query = table.concat({ "status=" .. status, "bytes=" .. body_bytes_sent }, "&")
+            -- 10.10.10.70 points to accounts service (alias not available when using resty-http)
+            local res, err = httpc:request_uri("http://10.10.10.70:3000/track/download/" .. skylink .. "?" .. query, {
+                method = "POST",
+                headers = { ["Cookie"] = "skynet-jwt=" .. jwt },
+            })
 
-        -- 10.10.10.70 points to accounts service (alias not available when using resty-http)
-        local res, err = httpc:request_uri("http://10.10.10.70:3000/track/download/" .. skylink .. "?" .. query, {
-            method = "POST",
-            headers = { ["Cookie"] = "skynet-jwt=" .. jwt },
-        })
+            if err or (res and res.status ~= ngx.HTTP_NO_CONTENT) then
+                ngx.log(ngx.ERR, "Failed accounts service request /track/download/" .. skylink .. ": ", err or ("[HTTP " .. res.status .. "] " .. res.body))
+            end
+        end
 
-        if err or (res and res.status ~= ngx.HTTP_NO_CONTENT) then
-            ngx.log(ngx.ERR, "Failed accounts service request /track/download/" .. skylink .. ": ", err or ("[HTTP " .. res.status .. "] " .. res.body))
+        if ngx.header["Skynet-Skylink"] and ngx.var.skynet_jwt ~= "" and ngx.status >= ngx.HTTP_OK and ngx.status < ngx.HTTP_SPECIAL_RESPONSE then
+            local ok, err = ngx.timer.at(0, track, ngx.header["Skynet-Skylink"], ngx.status, ngx.var.body_bytes_sent, ngx.var.skynet_jwt)
+            if err then ngx.log(ngx.ERR, "Failed to create timer: ", err) end
         end
     end
 
-    local function scan(premature, skylink, jwt)
-        if premature then return end
+    -- this block runs only when scanner module is enabled
+    if os.getenv("PORTAL_MODULES"):match("s") then
+        local function scan(premature, skylink)
+            if premature then return end
 
-        local httpc = require("resty.http").new()
+            local httpc = require("resty.http").new()
 
-        -- 10.10.10.101 points to malware-scanner service (alias not available when using resty-http)
-        local res, err = httpc:request_uri("http://10.10.10.101:4000/scan/" .. skylink, {
-            method = "POST",
-            headers = { ["Cookie"] = "skynet-jwt=" .. jwt },
-        })
+            -- 10.10.10.101 points to malware-scanner service (alias not available when using resty-http)
+            local res, err = httpc:request_uri("http://10.10.10.101:4000/scan/" .. skylink, {
+                method = "POST",
+            })
 
-        if err or (res and res.status ~= ngx.HTTP_OK) then
-            ngx.log(ngx.ERR, "Failed malware-scanner request /scan/" .. skylink .. ": ", err or ("[HTTP " .. res.status .. "] " .. res.body))
+            if err or (res and res.status ~= ngx.HTTP_OK) then
+                ngx.log(ngx.ERR, "Failed malware-scanner request /scan/" .. skylink .. ": ", err or ("[HTTP " .. res.status .. "] " .. res.body))
+            end
+        end
+
+        -- scan all skylinks but make sure to only run if skylink is present (empty if request failed)
+        if ngx.header["Skynet-Skylink"] then
+            local ok, err = ngx.timer.at(0, scan, ngx.header["Skynet-Skylink"])
+            if err then ngx.log(ngx.ERR, "Failed to create timer: ", err) end
         end
     end
-
-    if ngx.header["Skynet-Skylink"] and ngx.var.skynet_jwt ~= "" and ngx.status >= ngx.HTTP_OK and ngx.status < ngx.HTTP_SPECIAL_RESPONSE then
-        local ok, err = ngx.timer.at(0, track, ngx.header["Skynet-Skylink"], ngx.status, ngx.var.body_bytes_sent, ngx.var.skynet_jwt)
-        if err then ngx.log(ngx.ERR, "Failed to create timer: ", err) end
-    end
-
-    -- Unlike accounts, malware-scanner wants to be pinged about each skylink,
-    -- not only the ones downloaded by registered accounts.
-    local scan_ok, scan_err = ngx.timer.at(0, scan, ngx.header["Skynet-Skylink"], ngx.var.skynet_jwt)
-    if scan_err then ngx.log(ngx.ERR, "Failed to create timer: ", scan_err) end
 }

--- a/docker/nginx/conf.d/include/track-registry
+++ b/docker/nginx/conf.d/include/track-registry
@@ -1,27 +1,27 @@
 # register the registry access in accounts service (cookies should contain jwt)
 log_by_lua_block {
     -- this block runs only when accounts are enabled
-    if os.getenv("ACCOUNTS_ENABLED") ~= "true" then return end
+    if os.getenv("PORTAL_MODULES"):match("a") then
+        local function track(premature, request_method, jwt)
+            if premature then return end
 
-    local function track(premature, request_method, jwt)
-        if premature then return end
+            local httpc = require("resty.http").new()
+            local method = request_method == "GET" and "read" or "write"
 
-        local httpc = require("resty.http").new()
-        local method = request_method == "GET" and "read" or "write"
-
-        -- 10.10.10.70 points to accounts service (alias not available when using resty-http)
-        local res, err = httpc:request_uri("http://10.10.10.70:3000/track/registry/" .. method, {
-            method = "POST",
-            headers = { ["Cookie"] = "skynet-jwt=" .. jwt },
-        })
-        
-        if err or (res and res.status ~= ngx.HTTP_NO_CONTENT) then
-            ngx.log(ngx.ERR, "Failed accounts service request /track/registry/" .. method .. ": ", err or ("[HTTP " .. res.status .. "] " .. res.body))
+            -- 10.10.10.70 points to accounts service (alias not available when using resty-http)
+            local res, err = httpc:request_uri("http://10.10.10.70:3000/track/registry/" .. method, {
+                method = "POST",
+                headers = { ["Cookie"] = "skynet-jwt=" .. jwt },
+            })
+            
+            if err or (res and res.status ~= ngx.HTTP_NO_CONTENT) then
+                ngx.log(ngx.ERR, "Failed accounts service request /track/registry/" .. method .. ": ", err or ("[HTTP " .. res.status .. "] " .. res.body))
+            end
         end
-    end
 
-    if ngx.var.skynet_jwt ~= "" and (ngx.status == ngx.HTTP_OK or ngx.status == ngx.HTTP_NOT_FOUND) then
-        local ok, err = ngx.timer.at(0, track, ngx.req.get_method(), ngx.var.skynet_jwt)
-        if err then ngx.log(ngx.ERR, "Failed to create timer: ", err) end
+        if ngx.var.skynet_jwt ~= "" and (ngx.status == ngx.HTTP_OK or ngx.status == ngx.HTTP_NOT_FOUND) then
+            local ok, err = ngx.timer.at(0, track, ngx.req.get_method(), ngx.var.skynet_jwt)
+            if err then ngx.log(ngx.ERR, "Failed to create timer: ", err) end
+        end
     end
 }

--- a/docker/nginx/conf.d/include/track-registry
+++ b/docker/nginx/conf.d/include/track-registry
@@ -6,16 +6,19 @@ log_by_lua_block {
             if premature then return end
 
             local httpc = require("resty.http").new()
-            local method = request_method == "GET" and "read" or "write"
+
+            -- based on request method we assign a registry action string used 
+            -- in track endpoint namely "read" for GET and "write" for POST
+            local registry_action = request_method == "GET" and "read" or "write"
 
             -- 10.10.10.70 points to accounts service (alias not available when using resty-http)
-            local res, err = httpc:request_uri("http://10.10.10.70:3000/track/registry/" .. method, {
+            local res, err = httpc:request_uri("http://10.10.10.70:3000/track/registry/" .. registry_action, {
                 method = "POST",
                 headers = { ["Cookie"] = "skynet-jwt=" .. jwt },
             })
             
             if err or (res and res.status ~= ngx.HTTP_NO_CONTENT) then
-                ngx.log(ngx.ERR, "Failed accounts service request /track/registry/" .. method .. ": ", err or ("[HTTP " .. res.status .. "] " .. res.body))
+                ngx.log(ngx.ERR, "Failed accounts service request /track/registry/" .. registry_action .. ": ", err or ("[HTTP " .. res.status .. "] " .. res.body))
             end
         end
 

--- a/docker/nginx/conf.d/include/track-upload
+++ b/docker/nginx/conf.d/include/track-upload
@@ -1,47 +1,51 @@
 # register the upload in accounts service (cookies should contain jwt)
 log_by_lua_block {
     -- this block runs only when accounts are enabled
-    if os.getenv("ACCOUNTS_ENABLED") ~= "true" then return end
+    if os.getenv("PORTAL_MODULES"):match("a") then
+        local function track(premature, skylink, jwt)
+            if premature then return end
 
-    local function track(premature, skylink, jwt)
-        if premature then return end
+            local httpc = require("resty.http").new()
 
-        local httpc = require("resty.http").new()
+            -- 10.10.10.70 points to accounts service (alias not available when using resty-http)
+            local res, err = httpc:request_uri("http://10.10.10.70:3000/track/upload/" .. skylink, {
+                method = "POST",
+                headers = { ["Cookie"] = "skynet-jwt=" .. jwt },
+            })
 
-        -- 10.10.10.70 points to accounts service (alias not available when using resty-http)
-        local res, err = httpc:request_uri("http://10.10.10.70:3000/track/upload/" .. skylink, {
-            method = "POST",
-            headers = { ["Cookie"] = "skynet-jwt=" .. jwt },
-        })
+            if err or (res and res.status ~= ngx.HTTP_NO_CONTENT) then
+                ngx.log(ngx.ERR, "Failed accounts service request /track/upload/" .. skylink .. ": ", err or ("[HTTP " .. res.status .. "] " .. res.body))
+            end
+        end
 
-        if err or (res and res.status ~= ngx.HTTP_NO_CONTENT) then
-            ngx.log(ngx.ERR, "Failed accounts service request /track/upload/" .. skylink .. ": ", err or ("[HTTP " .. res.status .. "] " .. res.body))
+        -- report all skylinks (header empty if request failed) but only if jwt is preset (user is authenticated)
+        if ngx.header["Skynet-Skylink"] and ngx.var.skynet_jwt ~= "" then
+            local ok, err = ngx.timer.at(0, track, ngx.header["Skynet-Skylink"], ngx.var.skynet_jwt)
+            if err then ngx.log(ngx.ERR, "Failed to create timer: ", err) end
         end
     end
 
-    local function scan(premature, skylink, jwt)
-        if premature then return end
+    -- this block runs only when scanner module is enabled
+    if os.getenv("PORTAL_MODULES"):match("s") then
+        local function scan(premature, skylink)
+            if premature then return end
 
-        local httpc = require("resty.http").new()
+            local httpc = require("resty.http").new()
 
-        -- 10.10.10.101 points to malware-scanner service (alias not available when using resty-http)
-        local res, err = httpc:request_uri("http://10.10.10.101:4000/scan/" .. skylink, {
-            method = "POST",
-            headers = { ["Cookie"] = "skynet-jwt=" .. jwt },
-        })
+            -- 10.10.10.101 points to malware-scanner service (alias not available when using resty-http)
+            local res, err = httpc:request_uri("http://10.10.10.101:4000/scan/" .. skylink, {
+                method = "POST",
+            })
 
-        if err or (res and res.status ~= ngx.HTTP_OK) then
-            ngx.log(ngx.ERR, "Failed malware-scanner request /scan/" .. skylink .. ": ", err or ("[HTTP " .. res.status .. "] " .. res.body))
+            if err or (res and res.status ~= ngx.HTTP_OK) then
+                ngx.log(ngx.ERR, "Failed malware-scanner request /scan/" .. skylink .. ": ", err or ("[HTTP " .. res.status .. "] " .. res.body))
+            end
+        end
+
+        -- scan all skylinks but make sure to only run if skylink is present (empty if request failed)
+        if ngx.header["Skynet-Skylink"] then
+            local ok, err = ngx.timer.at(0, scan, ngx.header["Skynet-Skylink"])
+            if err then ngx.log(ngx.ERR, "Failed to create timer: ", err) end
         end
     end
-
-    if ngx.header["Skynet-Skylink"] and ngx.var.skynet_jwt ~= "" then
-        local ok, err = ngx.timer.at(0, track, ngx.header["Skynet-Skylink"], ngx.var.skynet_jwt)
-        if err then ngx.log(ngx.ERR, "Failed to create timer: ", err) end
-    end
-
-    -- Unlike accounts, malware-scanner wants to be pinged about each skylink,
-    -- not only the ones uploaded by registered accounts.
-    local scan_ok, scan_err = ngx.timer.at(0, scan, ngx.header["Skynet-Skylink"], ngx.var.skynet_jwt)
-    if scan_err then ngx.log(ngx.ERR, "Failed to create timer: ", scan_err) end
 }

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -180,7 +180,7 @@ location /skynet/skyfile {
 
     # access_by_lua_block {
     # 	-- this block runs only when accounts are enabled
-    # 	if os.getenv("ACCOUNTS_ENABLED") ~= "true" then return end
+    # 	if not os.getenv("PORTAL_MODULES"):match("a") then return end
 
     # 	ngx.var.upload_limit_rate = 5 * 1024 * 1024
     # 	local res = ngx.location.capture("/accounts/user", { copy_all_vars = true })
@@ -231,7 +231,7 @@ location /skynet/tus {
         ngx.req.set_header("SkynetMaxUploadSize", 5368709120)
 
         -- this block runs only when accounts are enabled
-        if os.getenv("ACCOUNTS_ENABLED") ~= "true" then return end
+        if not os.getenv("PORTAL_MODULES"):match("a") then return end
 
         local httpc = require("resty.http").new()
 
@@ -340,7 +340,7 @@ location /__internal/do/not/use/authenticated {
         local json = require('cjson')
 
         -- this block runs only when accounts are enabled
-        if os.getenv("ACCOUNTS_ENABLED") ~= "true" then
+        if not os.getenv("PORTAL_MODULES"):match("a") then
             ngx.say(json.encode{authenticated = false})
             return ngx.exit(ngx.HTTP_OK)
         end

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -28,7 +28,7 @@ worker_processes auto;
 # declare env variables to use it in config
 env SKYNET_PORTAL_API;
 env SKYNET_SERVER_API;
-env ACCOUNTS_ENABLED;
+env PORTAL_MODULES;
 
 events {
     worker_connections 8192;


### PR DESCRIPTION
- use PORTAL_MODULES env variable to discover services in nginx
- replace ACCOUNTS_ENABLED usage in nginx with PORTAL_MODULES
- run scanner /scan only if scanner module is enabled (check with PORTAL_MODULES)