### PR TITLE
move skyd mongo env variables to mongo docker compose file

### DIFF
--- a/docker-compose.mongodb.yml
+++ b/docker-compose.mongodb.yml
@@ -7,6 +7,12 @@ x-logging: &default-logging
     max-file: "3"
 
 services:
+  sia:
+    environment:
+      - MONGODB_URI=mongodb://${SKYNET_DB_HOST}:${SKYNET_DB_PORT}
+      - MONGODB_USER=${SKYNET_DB_USER}
+      - MONGODB_PASSWORD=${SKYNET_DB_PASS}
+
   mongo:
     image: mongo:4.4.1
     command: --keyFile=/data/mgkey --replSet=${SKYNET_DB_REPLICASET:-skynet}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,6 @@ services:
     logging: *default-logging
     environment:
       - SIA_MODULES=gctwra
-      - MONGODB_URI=mongodb://${SKYNET_DB_HOST}:${SKYNET_DB_PORT}
-      - MONGODB_USER=${SKYNET_DB_USER}
-      - MONGODB_PASSWORD=${SKYNET_DB_PASS}
 
     env_file:
       - .env


### PR DESCRIPTION
move skyd mongo env variables to docker-compose.mongo.yml to ensure they are only included when mongo is included (otherwise skyd would complain that MONGODB_URI is set but it cannot connect)