### PR TITLE
temporary backwards compatibility code for accounts on website

### DIFF
--- a/packages/website/src/components/Navigation/Navigation.js
+++ b/packages/website/src/components/Navigation/Navigation.js
@@ -41,8 +41,8 @@ const Navigation = ({ mode, uri }) => {
   }, [open]);
 
   const mobileMenuOffset = navRef.current ? navRef.current.offsetTop : 0;
-  const showLoginNavigation = accounts?.enabled && !accounts?.authenticated;
-  const showAccountNavigation = accounts?.enabled && accounts?.authenticated;
+  const showLoginNavigation = accounts && accounts.enabled !== false && !accounts?.authenticated;
+  const showAccountNavigation = accounts && accounts.enabled !== false && accounts?.authenticated;
 
   return (
     <nav

--- a/packages/website/src/components/Uploader/Uploader.js
+++ b/packages/website/src/components/Uploader/Uploader.js
@@ -52,8 +52,10 @@ const Uploader = () => {
   const [uploads, setUploads] = React.useState([]);
 
   const { data: accounts } = useAccounts();
-  const showAccountFeatures = accounts?.enabled && !accounts?.auth_required && !accounts?.authenticated;
-  const disabledComponent = accounts?.enabled && accounts?.auth_required && !accounts?.authenticated;
+  const showAccountFeatures =
+    accounts && accounts.enabled !== false && !accounts?.auth_required && !accounts?.authenticated;
+  const disabledComponent =
+    accounts && accounts.enabled !== false && accounts?.auth_required && !accounts?.authenticated;
 
   const onUploadStateChange = React.useCallback((id, state) => {
     setUploads((uploads) => {

--- a/packages/website/src/services/useAccounts.js
+++ b/packages/website/src/services/useAccounts.js
@@ -1,7 +1,11 @@
 import useSWR from "swr";
 
 const prefix = process.env.GATSBY_API_URL ?? "";
-const fetcher = (url) => fetch(`${prefix}${url}`).then((response) => response.json());
+const fetcher = (url) =>
+  fetch(`${prefix}${url}`)
+    .then((response) => response.json())
+    // temporary backwards compatibility code until new nginx code is deployed
+    .catch((error) => console.log(error) || fetcher(url.replace("/accounts", "/authenticated")));
 
 export default function useAccounts() {
   return useSWR("/__internal/do/not/use/accounts", fetcher);


### PR DESCRIPTION
since nginx endpoint name changed in new release and new website has already been deployed via skynet, we need backwards compatibility code until all production servers are updated

**important:** after all prod servers are redeployed, revert this pull request to clean up bc code