### PR TITLE
support auth only portal mode in health-check module

### DIFF
--- a/packages/health-check/src/checks/extended.js
+++ b/packages/health-check/src/checks/extended.js
@@ -2,7 +2,7 @@ const got = require("got");
 const hasha = require("hasha");
 const { detailedDiff } = require("deep-object-diff");
 const { isEqual } = require("lodash");
-const { calculateElapsedTime, ensureValidJSON, getResponseContent } = require("../utils");
+const { calculateElapsedTime, ensureValidJSON, getResponseContent, getAuthCookie } = require("../utils");
 const { parseSkylink } = require("skynet-js");
 
 // audioExampleCheck returns the result of trying to download the skylink
@@ -1130,12 +1130,13 @@ function parseHeaderString(header) {
 
 // skylinkVerification verifies a skylink against provided information.
 async function skylinkVerification(done, expected, { followRedirect = true, method = "get" } = {}) {
+  const authCookie = await getAuthCookie();
   const time = process.hrtime();
   const details = { name: expected.name, skylink: expected.skylink };
 
   try {
     const query = `${process.env.SKYNET_PORTAL_API}/${expected.skylink}`;
-    const response = await got[method](query, { followRedirect, headers: { cookie: "nocache=true" } });
+    const response = await got[method](query, { followRedirect, headers: { cookie: `nocache=true;${authCookie}` } });
     const entry = { ...details, up: true, statusCode: response.statusCode, time: calculateElapsedTime(time) };
     const info = {};
 

--- a/packages/health-check/src/index.js
+++ b/packages/health-check/src/index.js
@@ -4,8 +4,18 @@ if (!process.env.SKYNET_PORTAL_API) {
   throw new Error("You need to provide SKYNET_PORTAL_API environment variable");
 }
 
-if (process.env.ACCOUNTS_ENABLED === "true" && !process.env.SKYNET_DASHBOARD_URL) {
-  throw new Error("You need to provide SKYNET_DASHBOARD_URL environment variable when accounts are enabled");
+if (process.env.ACCOUNTS_ENABLED === "true") {
+  if (!process.env.SKYNET_DASHBOARD_URL) {
+    throw new Error("You need to provide SKYNET_DASHBOARD_URL environment variable when accounts are enabled");
+  }
+  if (process.env.ACCOUNTS_LIMIT_ACCESS === "authenticated") {
+    if (!process.env.ACCOUNTS_TEST_USER_EMAIL) {
+      throw new Error("ACCOUNTS_TEST_USER_EMAIL cannot be empty");
+    }
+    if (!process.env.ACCOUNTS_TEST_USER_PASSWORD) {
+      throw new Error("ACCOUNTS_TEST_USER_PASSWORD cannot be empty");
+    }
+  }
 }
 
 const express = require("express");

--- a/packages/health-check/src/utils.js
+++ b/packages/health-check/src/utils.js
@@ -1,3 +1,5 @@
+const got = require("got");
+
 /**
  * Get the time between start and now in milliseconds
  */
@@ -39,9 +41,60 @@ function ensureValidJSON(object) {
   return JSON.parse(stringified);
 }
 
+/**
+ * Authenticate with given credentials and return auth cookie
+ * Creates new account if username does not exist
+ * Only authenticates when portal is set to authenticated users only mode
+ */
+function getAuthCookie() {
+  // cache auth promise so only one actual request will be made
+  if (getAuthCookie.cache) return getAuthCookie.cache;
+
+  // do not authenticate if it is not necessary
+  if (process.env.ACCOUNTS_LIMIT_ACCESS !== "authenticated") return {};
+
+  const email = process.env.ACCOUNTS_TEST_USER_EMAIL;
+  const password = process.env.ACCOUNTS_TEST_USER_PASSWORD;
+
+  if (!email) throw new Error("ACCOUNTS_TEST_USER_EMAIL cannot be empty");
+  if (!password) throw new Error("ACCOUNTS_TEST_USER_PASSWORD cannot be empty");
+
+  async function authenticate() {
+    try {
+      // authenticate with given test credentials
+      const response = await got.post(`${process.env.SKYNET_DASHBOARD_URL}/api/login`, {
+        json: { email, password },
+      });
+
+      // extract set-cookie from successful authentication request
+      const cookies = response.headers["set-cookie"];
+
+      // find the skynet-jwt cookie
+      const jwtcookie = cookies.find((cookie) => cookie.startsWith("skynet-jwt"));
+
+      // extract just the cookie value (no set-cookie props) from set-cookie
+      return jwtcookie.match(/skynet-jwt=[^;]+;/)[0];
+    } catch (error) {
+      // 401 means that service worked but user could not have been authenticated
+      if (error.response && error.response.statusCode === 401) {
+        // sign up with the given credentials
+        await got.post(`${process.env.SKYNET_DASHBOARD_URL}/api/user`, {
+          json: { email, password },
+        });
+
+        // retry authentication
+        return authenticate();
+      }
+    }
+  }
+
+  return (getAuthCookie.cache = authenticate());
+}
+
 module.exports = {
   calculateElapsedTime,
   getYesterdayISOString,
   getResponseContent,
   ensureValidJSON,
+  getAuthCookie,
 };


### PR DESCRIPTION
When portal is set to allow only authenticated users traffic with `ACCOUNTS_LIMIT_ACCESS` set to `authenticated`, health checks will fail since there was no concept of authentication there before, we were health-checking only with anonymous user on public endpoints. We need to send authenticated requests via health-check so we either need a registered user. 

Easiest thing to do at the moment is just programmatically create a user, sign in and use skynet-jwt cookie in health-check requests. We don't want to create a new user every time we run health-checks so we need to provide username and password with `ACCOUNTS_TEST_USER_EMAIL` and `ACCOUNTS_TEST_USER_PASSWORD` (can be either shared on all servers or each server can have it's own). We don't need to manually create the user, for the first time the credentials are used (user doesn't exist), health-check will create the user automatically.

Note: when portal is set to only accept authenticated traffic, health-check module will fail if both `ACCOUNTS_TEST_USER_EMAIL` and `ACCOUNTS_TEST_USER_PASSWORD` are provided, just to make sure that portal would not come up fully until these requirements are met.

Example credentials (email prefixed with healthcheck followed by random number and some random but secure password):
```bash
ACCOUNTS_TEST_USER_EMAIL=healthcheck+812739871246@siasky.net
ACCOUNTS_TEST_USER_PASSWORD=xBE4DVeuv83NtS9LeY3cU9oFtF19a0GTyZEvFUpcjsn3SiH
```