### PR TITLE
allow to use skyd api password from env

### DIFF
--- a/docker/nginx/libs/skynet/utils.lua
+++ b/docker/nginx/libs/skynet/utils.lua
@@ -1,14 +1,19 @@
 local _M = {}
 
 function _M.authorization_header()
-    local b64 = require("ngx.base64")
-    -- open apipassword file for reading (b flag is required for some reason)
-    -- (file /etc/.sia/apipassword has to be mounted from the host system)
-    local apipassword_file = io.open("/data/sia/apipassword", "rb")
-    -- read apipassword file contents and trim newline (important)
-    local apipassword = apipassword_file:read("*all"):gsub("%s+", "")
-    -- make sure to close file after reading the password
-    apipassword_file.close()
+    -- read api password from env variable
+    local apipassword = os.getenv("SIA_API_PASSWORD")
+    -- if api password is not available as env variable, read it from disk
+    if not apipassword then
+        local b64 = require("ngx.base64")
+        -- open apipassword file for reading (b flag is required for some reason)
+        -- (file /etc/.sia/apipassword has to be mounted from the host system)
+        local apipassword_file = io.open("/data/sia/apipassword", "rb")
+        -- read apipassword file contents and trim newline (important)
+        apipassword = apipassword_file:read("*all"):gsub("%s+", "")
+        -- make sure to close file after reading the password
+        apipassword_file.close()
+    end
     -- encode the user:password authorization string
     -- (in our case user is empty so it is just :password)
     local content = b64.encode_base64url(":" .. apipassword)

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -30,6 +30,7 @@ env SKYNET_PORTAL_API;
 env SKYNET_SERVER_API;
 env PORTAL_MODULES;
 env ACCOUNTS_LIMIT_ACCESS;
+env SIA_API_PASSWORD;
 
 events {
     worker_connections 8192;


### PR DESCRIPTION
if `SIA_API_PASSWORD` is defined in .env file then it will be used in nginx to authenticate requests instead of the api password from disk