### PR TITLE
fix empty check on nginx sourced env variable

### DIFF
--- a/docker/nginx/libs/skynet/utils.lua
+++ b/docker/nginx/libs/skynet/utils.lua
@@ -4,8 +4,7 @@ function _M.authorization_header()
     -- read api password from env variable
     local apipassword = os.getenv("SIA_API_PASSWORD")
     -- if api password is not available as env variable, read it from disk
-    if not apipassword then
-        local b64 = require("ngx.base64")
+    if apipassword == nil or apipassword == "" then
         -- open apipassword file for reading (b flag is required for some reason)
         -- (file /etc/.sia/apipassword has to be mounted from the host system)
         local apipassword_file = io.open("/data/sia/apipassword", "rb")
@@ -16,7 +15,7 @@ function _M.authorization_header()
     end
     -- encode the user:password authorization string
     -- (in our case user is empty so it is just :password)
-    local content = b64.encode_base64url(":" .. apipassword)
+    local content = require("ngx.base64").encode_base64url(":" .. apipassword)
     -- set authorization header with proper base64 encoded string
     return "Basic " .. content
 end


### PR DESCRIPTION
- fix critical issue with b64 being undefined (bad copy and paste)
- nginx should use api password file if `SIA_API_PASSWORD` env variable is defined but empty (that's how skyd works too)