### PR TITLE
enable cors on /logout endpoint

### DIFF
--- a/docker/nginx/conf.d/server/server.account
+++ b/docker/nginx/conf.d/server/server.account
@@ -42,3 +42,10 @@ location /api/login {
     rewrite /api/(.*) /$1 break;
     proxy_pass http://accounts:3000;
 }
+
+location /api/logout {
+    include /etc/nginx/conf.d/include/cors;
+
+    rewrite /api/(.*) /$1 break;
+    proxy_pass http://accounts:3000;
+}


### PR DESCRIPTION
enable cors on /logout accounts endpoint to match /login and /register behaviour 