### PR TITLE
check if blocklist is not null

### DIFF
--- a/docker/nginx/libs/skynet/blocklist.lua
+++ b/docker/nginx/libs/skynet/blocklist.lua
@@ -26,9 +26,12 @@ function _M.reload()
         -- mark all existing entries as expired
         ngx.shared.blocklist:flush_all()
 
-        -- set all cache entries one by one (resets expiration)
-        for i, hash in ipairs(data.blocklist) do
-            ngx.shared.blocklist:set(hash, true)
+        -- check if blocklist is table (it is null when empty)
+        if type(data.blocklist) == "table" then
+            -- set all cache entries one by one (resets expiration)
+            for i, hash in ipairs(data.blocklist) do
+                ngx.shared.blocklist:set(hash, true)
+            end
         end
 
         -- ensure that init flag is persisted


### PR DESCRIPTION
Fixes error where blocklist is null when it's empty.

```
2022/01/20 10:00:03 [error] 627#627: *5761 lua entry thread aborted: runtime error: /etc/nginx/libs/skynet/blocklist.lua:30: bad argument #1 to 'ipairs' (table expected, got userdata)
stack traceback:
coroutine 0:
	[C]: in function 'ipairs'
	/etc/nginx/libs/skynet/blocklist.lua:30: in function 'reload'
	/etc/nginx/libs/skynet/blocklist.lua:44: in function 'is_blocked'
	access_by_lua(location-skylink:77):29: in main chunk, client: 10.10.10.1, server: [redacted], request: "GET /AACogzrAimYPG42tDOKhS3lXZD8YvlF8Q8R17afe95iV2Q HTTP/1.1", host: "[redacted]"
```