### PR TITLE
ACCOUNTS_LIMIT_ACCESS missing when it defaults

### DIFF
--- a/docker-compose.accounts.yml
+++ b/docker-compose.accounts.yml
@@ -17,6 +17,7 @@ services:
   health-check:
     environment:
       - ACCOUNTS_ENABLED=true
+      - ACCOUNTS_LIMIT_ACCESS=${ACCOUNTS_LIMIT_ACCESS:-authenticated} # default to authenticated access only
 
   accounts:
     build:


### PR DESCRIPTION
`ACCOUNTS_LIMIT_ACCESS` was missing from env variables in health-check service. The reason for that was that we default the value of that variable on nginx only and if this variable does not exist in .env file, it will not propagate to health-check container. Solution was to simply copy the same default on health-check service, similarly to how we handled `ACCOUNTS_ENABLED`.