### PR TITLE
unique SERVER_UID

### DIFF
--- a/dc
+++ b/dc
@@ -10,6 +10,24 @@ if [ -f .env ]; then
   IFS=$'\n'
   for x in $(grep -v '^#.*' .env); do export $x; done
   IFS=$OLD_IFS
+else
+  # ensure a .env is present
+  touch .env
+fi
+
+if [ -z $(cat .env | grep -i '^SERVER_UID=') ];
+then
+  # add a SERVER_UID to .env if none was found
+  SERVER_UID=$(openssl rand -hex 8)
+  printf "# randomly generated 16 character string that must be unique across servers\nSERVER_UID=$SERVER_UID" >> .env
+  printf "\nIMPORTANT NOTE: added SERVER_UID '$SERVER_UID' to .env file\n\n"
+elif [ -z $(cat .env | grep -E -i '^SERVER_UID=[0-9A-F]{16}') ];
+then
+  # ensure the SERVER_UID is a valid 16 char hex string if the current value was
+  # either empty or malformed
+  SERVER_UID=$(openssl rand -hex 8)
+  sed -i '' "/^SERVER_UID=/s/=.*/=$SERVER_UID/" .env
+  printf "\nIMPORTANT NOTE: added SERVER_UID '$SERVER_UID' to .env file\n\n"
 fi
 
 # include base docker compose file

--- a/dc
+++ b/dc
@@ -12,13 +12,13 @@ if [ -f .env ]; then
   IFS=$OLD_IFS
 fi
 
-if [ -z $(cat .env | grep -i '^SERVER_UID=') ];
+if [ -z $(grep -i '^SERVER_UID=' .env) ];
 then
   # add a SERVER_UID to .env if none was found
   SERVER_UID=$(openssl rand -hex 8)
   printf "\n# must be unique across servers\nSERVER_UID=$SERVER_UID" >> .env
   printf "\nIMPORTANT NOTE: added SERVER_UID '$SERVER_UID' to .env file\n\n"
-elif [ -z $(cat .env | grep -E -i '^SERVER_UID=.+') ];
+elif [ -z $(grep -E -i '^SERVER_UID=.+' .env) ];
 then
   # ensure the SERVER_UID is set if the current value is empty
   SERVER_UID=$(openssl rand -hex 8)

--- a/dc
+++ b/dc
@@ -19,12 +19,11 @@ if [ -z $(cat .env | grep -i '^SERVER_UID=') ];
 then
   # add a SERVER_UID to .env if none was found
   SERVER_UID=$(openssl rand -hex 8)
-  printf "\n# randomly generated 16 character string that must be unique across servers\nSERVER_UID=$SERVER_UID" >> .env
+  printf "\n# must be unique across servers\nSERVER_UID=$SERVER_UID" >> .env
   printf "\nIMPORTANT NOTE: added SERVER_UID '$SERVER_UID' to .env file\n\n"
-elif [ -z $(cat .env | grep -E -i '^SERVER_UID=[0-9A-F]{16}') ];
+elif [ -z $(cat .env | grep -E -i '^SERVER_UID=.+') ];
 then
-  # ensure the SERVER_UID is a valid 16 char hex string if the current value was
-  # either empty or malformed
+  # ensure the SERVER_UID is set if the current value is empty
   SERVER_UID=$(openssl rand -hex 8)
   sed -i '' "/^SERVER_UID=/s/=.*/=$SERVER_UID/" .env
   printf "\nIMPORTANT NOTE: added SERVER_UID '$SERVER_UID' to .env file\n\n"

--- a/dc
+++ b/dc
@@ -10,9 +10,6 @@ if [ -f .env ]; then
   IFS=$'\n'
   for x in $(grep -v '^#.*' .env); do export $x; done
   IFS=$OLD_IFS
-else
-  # ensure a .env is present
-  touch .env
 fi
 
 if [ -z $(cat .env | grep -i '^SERVER_UID=') ];

--- a/dc
+++ b/dc
@@ -19,7 +19,7 @@ if [ -z $(cat .env | grep -i '^SERVER_UID=') ];
 then
   # add a SERVER_UID to .env if none was found
   SERVER_UID=$(openssl rand -hex 8)
-  printf "# randomly generated 16 character string that must be unique across servers\nSERVER_UID=$SERVER_UID" >> .env
+  printf "\n# randomly generated 16 character string that must be unique across servers\nSERVER_UID=$SERVER_UID" >> .env
   printf "\nIMPORTANT NOTE: added SERVER_UID '$SERVER_UID' to .env file\n\n"
 elif [ -z $(cat .env | grep -E -i '^SERVER_UID=[0-9A-F]{16}') ];
 then


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR extends the `dc` command with some scripting that ensures the `.env` file has a valid `SERVER_UID`.

## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings

## Issues Closed
N/A

## Testing

I would appreciate if someone would test this. I tested it myself with:
- no .env file
- a .env file with an invalid `SERVER_UID`
- a .env file with an empty `SERVER_UID`
- a .env file with a valid `SERVER_UID`