### PR TITLE
Simple fix for Login URL formatting of double slash

### DIFF
--- a/packages/website/src/components/Navigation/Navigation.js
+++ b/packages/website/src/components/Navigation/Navigation.js
@@ -101,7 +101,7 @@ const Navigation = ({ mode, uri }) => {
             )}
 
             {showAccountNavigation && (
-              <Link href={accountsUrl} className="button-primary">
+              <Link href={createAccountsUrl()} className="button-primary">
                 My account
               </Link>
             )}
@@ -144,18 +144,18 @@ const Navigation = ({ mode, uri }) => {
             <div className="flex items-center justify-center px-4 space-x-6">
               {showLoginNavigation && (
                 <>
-                  <Link href={`${accountsUrl}auth/login`} className="button-secondary-light">
+                  <Link href={createAccountsUrl("auth/login")} className="button-secondary-light">
                     Log in
                   </Link>
 
-                  <Link href={`${accountsUrl}auth/registration`} className="button-primary">
+                  <Link href={createAccountsUrl("/auth/registration")} className="button-primary">
                     Sign up
                   </Link>
                 </>
               )}
 
               {showAccountNavigation && (
-                <Link href={accountsUrl} className="button-primary">
+                <Link href={createAccountsUrl()} className="button-primary">
                   My account
                 </Link>
               )}

--- a/packages/website/src/components/Navigation/Navigation.js
+++ b/packages/website/src/components/Navigation/Navigation.js
@@ -90,11 +90,11 @@ const Navigation = ({ mode, uri }) => {
 
             {showLoginNavigation && (
               <>
-                <Link href={`${accountsUrl}/auth/login`} className="button-link-primary">
+                <Link href={`${accountsUrl}auth/login`} className="button-link-primary">
                   Log in
                 </Link>
 
-                <Link href={`${accountsUrl}/auth/registration`} className="button-primary">
+                <Link href={`${accountsUrl}auth/registration`} className="button-primary">
                   Sign up
                 </Link>
               </>
@@ -144,11 +144,11 @@ const Navigation = ({ mode, uri }) => {
             <div className="flex items-center justify-center px-4 space-x-6">
               {showLoginNavigation && (
                 <>
-                  <Link href={`${accountsUrl}/auth/login`} className="button-secondary-light">
+                  <Link href={`${accountsUrl}auth/login`} className="button-secondary-light">
                     Log in
                   </Link>
 
-                  <Link href={`${accountsUrl}/auth/registration`} className="button-primary">
+                  <Link href={`${accountsUrl}auth/registration`} className="button-primary">
                     Sign up
                   </Link>
                 </>

--- a/packages/website/src/components/Navigation/Navigation.js
+++ b/packages/website/src/components/Navigation/Navigation.js
@@ -26,7 +26,7 @@ const Navigation = ({ mode, uri }) => {
   const windowSize = useWindowSize();
   const isWindowTop = useWindowTop();
   const { data: accounts } = useAccounts();
-  const accountsUrl = useAccountsUrl();
+  const createAccountsUrl = useAccountsUrl();
 
   React.useEffect(() => {
     setOpen(false);
@@ -90,11 +90,11 @@ const Navigation = ({ mode, uri }) => {
 
             {showLoginNavigation && (
               <>
-                <Link href={`${accountsUrl}auth/login`} className="button-link-primary">
+                <Link href={createAccountsUrl("/auth/login")} className="button-link-primary">
                   Log in
                 </Link>
 
-                <Link href={`${accountsUrl}auth/registration`} className="button-primary">
+                <Link href={createAccountsUrl("/auth/registration")} className="button-primary">
                   Sign up
                 </Link>
               </>

--- a/packages/website/src/components/Uploader/Uploader.js
+++ b/packages/website/src/components/Uploader/Uploader.js
@@ -26,7 +26,7 @@ const RegistrationLink = () => {
 
   return (
     <Link
-      href={`${accountsUrl}/auth/registration`}
+      href={`${accountsUrl}auth/registration`}
       className="uppercase underline-primary hover:text-primary transition-colors duration-200"
     >
       Sign up
@@ -39,7 +39,7 @@ const LogInLink = () => {
 
   return (
     <Link
-      href={`${accountsUrl}/auth/login`}
+      href={`${accountsUrl}auth/login`}
       className="uppercase underline-primary hover:text-primary transition-colors duration-200"
     >
       Log in

--- a/packages/website/src/components/Uploader/Uploader.js
+++ b/packages/website/src/components/Uploader/Uploader.js
@@ -22,11 +22,11 @@ const getRootDirectory = (file) => {
 };
 
 const RegistrationLink = () => {
-  const accountsUrl = useAccountsUrl();
+  const createAccountsUrl = useAccountsUrl();
 
   return (
     <Link
-      href={`${accountsUrl}auth/registration`}
+      href={createAccountsUrl("auth/registration")}
       className="uppercase underline-primary hover:text-primary transition-colors duration-200"
     >
       Sign up
@@ -35,11 +35,11 @@ const RegistrationLink = () => {
 };
 
 const LogInLink = () => {
-  const accountsUrl = useAccountsUrl();
+  const createAccountsUrl = useAccountsUrl();
 
   return (
     <Link
-      href={`${accountsUrl}auth/login`}
+      href={createAccountsUrl("auth/login")}
       className="uppercase underline-primary hover:text-primary transition-colors duration-200"
     >
       Log in

--- a/packages/website/src/services/useAccountsUrl.js
+++ b/packages/website/src/services/useAccountsUrl.js
@@ -3,7 +3,7 @@ import skynetClient from "./skynetClient";
 
 export default function useAccountsUrl() {
   const [url, setUrl] = React.useState("");
-  const createAccountsUrl = React.useCallback((path = "") => new URL(path, url).toString(), [url]);
+  const createAccountsUrl = React.useCallback((path = "") => url && new URL(path, url).toString(), [url]);
 
   React.useEffect(() => {
     (async function resolve() {

--- a/packages/website/src/services/useAccountsUrl.js
+++ b/packages/website/src/services/useAccountsUrl.js
@@ -3,6 +3,7 @@ import skynetClient from "./skynetClient";
 
 export default function useAccountsUrl() {
   const [url, setUrl] = React.useState("");
+  const createAccountsUrl = React.useCallback((path = "") => new URL(path, url).toString(), [url]);
 
   React.useEffect(() => {
     (async function resolve() {
@@ -14,5 +15,5 @@ export default function useAccountsUrl() {
     })();
   }, [setUrl]);
 
-  return url;
+  return createAccountsUrl;
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview
Currently, URLs for login and signup are formatted to look like: `https://account.skynetpro.net//auth/login`, using a double slash.

![image](https://user-images.githubusercontent.com/4205837/151833689-c9c73c9b-c575-458a-9e8f-e95713d9ec74.png)

I'm unsure if there is code elsewhere to ensure that accountsUrl ends with a `/`, but I doubt the react app is the place for that logic anyways.