### PR TITLE
add ttl for dns entry used for ssl challenge

### DIFF
--- a/docker/caddy/caddy.json.template
+++ b/docker/caddy/caddy.json.template
@@ -25,7 +25,8 @@
                   "dns": {
                     "provider": {
                       "name": "route53"
-                    }
+                    },
+                    "ttl": "30m"
                   }
                 }
               }


### PR DESCRIPTION
Set up 30 minutes time to live on caddy generated dns entries used for dns-01 challenge. We've had multiple issues with dangling dns entries that prevented certificate renewals.

https://caddyserver.com/docs/json/apps/tls/automation/policies/issuers/acme/challenges/dns/ttl/

closes #1645 