### PR TITLE
require server uid env var for blocker service

### DIFF
--- a/docker-compose.blocker.yml
+++ b/docker-compose.blocker.yml
@@ -21,6 +21,8 @@ services:
     logging: *default-logging
     env_file:
       - .env
+    environment:
+      - SERVER_UID=${SERVER_UID:?cannot be empty}
     volumes:
       - ./docker/data/nginx/blocker:/data/nginx/blocker
     expose:


### PR DESCRIPTION
When `SERVER_UID` is not set or empty, docker will throw an error when trying to start the stack.

```bash
➜  skynet-webportal git:(master) ✗ ./dc up
invalid interpolation format for services.sia.environment.[]: "required variable SERVER_UID is missing a value: cannot be empty". You may need to escape any $ with another $.
```