### PR TITLE
expose internal authenticate function on health-check cli

### DIFF
--- a/packages/health-check/bin/cli
+++ b/packages/health-check/bin/cli
@@ -7,6 +7,16 @@ require("yargs/yargs")(process.argv.slice(2))
   .demandCommand()
   .strict(true)
   .command(
+    "__authenticate", // Internal only function - this function will be removed when API keys are implemented
+    false, // hide this function cli help
+    () => {},
+    async () => {
+      const { getAuthCookie } = require("../src/utils");
+
+      console.log(await getAuthCookie(true));
+    }
+  )
+  .command(
     "enable",
     "Mark portal as enabled",
     () => {},

--- a/packages/health-check/src/utils.js
+++ b/packages/health-check/src/utils.js
@@ -45,24 +45,35 @@ function ensureValidJSON(object) {
  * Authenticate with given credentials and return auth cookie
  * Creates new account if username does not exist
  * Only authenticates when portal is set to authenticated users only mode
+ * @param {boolean} forceAuth forcibly ensure authentication with test credentials
  */
-function getAuthCookie() {
+function getAuthCookie(forceAuth = false) {
   // cache auth promise so only one actual request will be made
   if (getAuthCookie.cache) return getAuthCookie.cache;
 
-  // do not authenticate if it is not necessary
-  if (!["authenticated", "subscription"].includes(process.env.ACCOUNTS_LIMIT_ACCESS)) return {};
+  // accounts disabled, do not try to authenticate
+  if (!isPortalModuleEnabled("a")) return "";
 
+  // do not authenticate if it is not required by portal limit access rule
+  if (!forceAuth && !["authenticated", "subscription"].includes(process.env.ACCOUNTS_LIMIT_ACCESS)) return "";
+
+  const portalDomain = process.env.PORTAL_DOMAIN;
   const email = process.env.ACCOUNTS_TEST_USER_EMAIL;
   const password = process.env.ACCOUNTS_TEST_USER_PASSWORD;
 
-  if (!email) throw new Error("ACCOUNTS_TEST_USER_EMAIL cannot be empty");
-  if (!password) throw new Error("ACCOUNTS_TEST_USER_PASSWORD cannot be empty");
+  try {
+    if (!portalDomain) throw new Error("PORTAL_DOMAIN cannot be empty");
+    if (!email) throw new Error("ACCOUNTS_TEST_USER_EMAIL cannot be empty");
+    if (!password) throw new Error("ACCOUNTS_TEST_USER_PASSWORD cannot be empty");
+  } catch (error) {
+    console.log(error.message);
+    process.exit(1);
+  }
 
   async function authenticate() {
     try {
       // authenticate with given test user credentials
-      const response = await got.post(`${process.env.SKYNET_DASHBOARD_URL}/api/login`, {
+      const response = await got.post(`https://account.${process.env.PORTAL_DOMAIN}/api/login`, {
         json: { email, password },
       });
 
@@ -84,7 +95,7 @@ function getAuthCookie() {
       // 401 means that service worked but user could not have been authenticated
       if (error.response && error.response.statusCode === 401) {
         // sign up with the given credentials
-        await got.post(`${process.env.SKYNET_DASHBOARD_URL}/api/user`, {
+        await got.post(`https://account.${process.env.PORTAL_DOMAIN}/api/user`, {
           json: { email, password },
         });
 


### PR DESCRIPTION
Adds function that takes env variables and authenticates user returning auth cookie.

**note:** this function will be removed when api keys are implemented

Usage example:

`docker exec health-check cli __authenticate`

On success: prints cookie in a format `skynet-jwt=cookie-value-here;`
On error: exits with code 1

Required env variables:
- `PORTAL_MODULES` - must include "a"
- `ACCOUNTS_TEST_USER_EMAIL` - test user email
- `ACCOUNTS_TEST_USER_PASSWORD` - test user password
- `PORTAL_DOMAIN` - current portal domain