### PR TITLE
escape uri on subdomain skylink requests

### DIFF
--- a/changelog/items/bugs-fixed/escape-uri-on-subdomain-skylink-requests.md
+++ b/changelog/items/bugs-fixed/escape-uri-on-subdomain-skylink-requests.md
@@ -1,0 +1,1 @@
+- fixed a bug when accessing file from skylink via subdomain with a filename that had escaped characters

--- a/docker/nginx/conf.d/server/server.skylink
+++ b/docker/nginx/conf.d/server/server.skylink
@@ -9,7 +9,7 @@ location / {
     set_by_lua_block $path {
         -- strip ngx.var.request_uri from query params - this is basically the same as ngx.var.uri but
         -- do not use ngx.var.uri because it will already be unescaped and we need to use escaped path
-        -- examples: escaped uri "/b%20r56+7" and unescaped uri: "/b r56 7"
+        -- examples: escaped uri "/b%20r56+7" and unescaped uri "/b r56 7"
         return string.gsub(ngx.var.request_uri, "?.*", "")
     }
 

--- a/docker/nginx/conf.d/server/server.skylink
+++ b/docker/nginx/conf.d/server/server.skylink
@@ -6,7 +6,12 @@ include /etc/nginx/conf.d/include/init-optional-variables;
 
 location / {
     set_by_lua_block $skylink { return string.match(ngx.var.host, "%w+") }
-    set $path $uri;
+    set_by_lua_block $path {
+        -- strip ngx.var.request_uri from query params - this is basically the same as ngx.var.uri but
+        -- do not use ngx.var.uri because it will already be unescaped and we need to use escaped path
+        -- examples: escaped uri "/b%20r56+7" and unescaped uri: "/b r56 7"
+        return string.gsub(ngx.var.request_uri, "?.*", "")
+    }
 
     include /etc/nginx/conf.d/include/location-skylink;
 }


### PR DESCRIPTION
Fixes a bug when accessing file from skylink with a filename that had escaped characters.
The issue was that we assigned `$uri` as a file path but `$uri` in nginx contains already unescaped uri string so `/file%201.txt` would become `/file 1.txt` which when passed to proxy_pass resulted in an issue from skyd.
The solution was to use `$request_uri` that in nginx is the full,  original, escaped request uri with query params and then strip it from query params since those should not be a part of our `$path` variable.
I also tried easier approach by just escaping `$uri` but it also escaped `/` so it resulted in malformed uri hence `$request_uri` approach was the only valid one.

closes https://github.com/SkynetLabs/skynet-webportal/issues/1384