### PR TITLE
Fewer non-actionable alerts

### DIFF
--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -39,6 +39,16 @@ def exec(command):
 
 
 async def block_skylinks_from_airtable():
+    # Get nginx's IP before doing anything else. If this step fails we don't
+    # need to continue with the execution of the script.
+    ipaddress = exec(
+        "docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' nginx"
+    )
+
+    if ipaddress == "":
+        print("Nginx's IP could not be detected. Exiting.")
+        return
+
     print("Pulling blocked skylinks from Airtable via api integration")
     headers = {"Authorization": "Bearer " + AIRTABLE_API_KEY}
     skylinks = []
@@ -121,14 +131,6 @@ async def block_skylinks_from_airtable():
             + " of the skylinks returned from Airtable are not valid"
         )
         await send_msg(message, file=("\n".join(invalid_skylinks)))
-
-    ipaddress = exec(
-        "docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' nginx"
-    )
-
-    if ipaddress == "":
-        print("Nginx's IP could not be detected. Exiting.")
-        return
 
     print("Sending blocklist request to siad through nginx")
     response = requests.post(

--- a/setup-scripts/blocklist-airtable.py
+++ b/setup-scripts/blocklist-airtable.py
@@ -126,6 +126,10 @@ async def block_skylinks_from_airtable():
         "docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' nginx"
     )
 
+    if ipaddress == "":
+        print("Nginx's IP could not be detected. Exiting.")
+        return
+
     print("Sending blocklist request to siad through nginx")
     response = requests.post(
         "http://" + ipaddress + ":8000/skynet/blocklist",


### PR DESCRIPTION
# PULL REQUEST

## Overview

Our monitoring channels are often spammed with notifications which ping the team. Some of those are important and actionable but others are not. We need to actively work on weeding out the non-actionable alerts in order to decrease the distractions those cause and to increase the chance that someone would go and fix them.

This PR addresses the case in which nginx is stopped on a given server but the crontab is still executing the blocklisting task. This situation leads to Discord pings because the task appears to have failed with an error. In reality we don't care about this situation because if nginx is not running then the server is not serving bad content anyway. This is a non-actionable problem which will self-resolve when nginx is brought back up and the blocklisting cron is re-run.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
