### PR TITLE
remove portal name env var

### DIFF
--- a/docker-compose.jaeger.yml
+++ b/docker-compose.jaeger.yml
@@ -10,7 +10,7 @@ services:
   sia:
     environment:
       - JAEGER_DISABLED=${JAEGER_DISABLED:-false} # Enable/Disable tracing
-      - JAEGER_SERVICE_NAME=${PORTAL_NAME:-Skyd} # change to e.g. eu-ger-1
+      - JAEGER_SERVICE_NAME=${SERVER_DOMAIN:-Skyd} # change to e.g. eu-ger-1
       # Configuration
       # See https://github.com/jaegertracing/jaeger-client-go#environment-variables
       # for all options.

--- a/setup-scripts/README.md
+++ b/setup-scripts/README.md
@@ -102,7 +102,6 @@ At this point we have almost everything running, we just need to set up your wal
    - `CLOUDFLARE_AUTH_TOKEN` (optional) if using cloudflare as dns loadbalancer (need to change it in Caddyfile too)
    - `AWS_ACCESS_KEY_ID` (optional) if using route53 as a dns loadbalancer
    - `AWS_SECRET_ACCESS_KEY` (optional) if using route53 as a dns loadbalancer
-   - `PORTAL_NAME` a string representing name of your portal e.g. `siasky.xyz` or `my skynet portal`
    - `DISCORD_WEBHOOK_URL` (required if using Discord notifications) discord webhook url (generate from discord app)
    - `DISCORD_MENTION_USER_ID` (optional) add `/cc @user` mention to important messages from webhook (has to be id not user name)
    - `DISCORD_MENTION_ROLE_ID` (optional) add `/cc @role` mention to important messages from webhook (has to be id not role name)

--- a/setup-scripts/setup-docker-services.sh
+++ b/setup-scripts/setup-docker-services.sh
@@ -31,7 +31,6 @@ docker-compose --version # sanity check
 # * AWS_ACCESS_KEY_ID - (optional) if using route53 as a dns loadbalancer
 # * AWS_SECRET_ACCESS_KEY - (optional) if using route53 as a dns loadbalancer
 # * API_PORT - (optional) the port on which siad is listening, defaults to 9980
-# * PORTAL_NAME - a string representing name of your portal e.g. `siasky.xyz` or `my skynet portal` (internal use only)
 # * DISCORD_WEBHOOK_URL - (required if using Discord notifications) discord webhook url (generate from discord app)
 # * DISCORD_MENTION_USER_ID - (optional) add `/cc @user` mention to important messages from webhook (has to be id not user name)
 # * DISCORD_MENTION_ROLE_ID - (optional) add `/cc @role` mention to important messages from webhook (has to be id not role name)
@@ -44,7 +43,7 @@ docker-compose --version # sanity check
 # * COOKIE_ENC_KEY - (optional) if using `accounts` encryption key, at least 32 bytes
 if ! [ -f /home/user/skynet-webportal/.env ]; then
     HSD_API_KEY=$(openssl rand -base64 32) # generate safe random key for handshake
-    printf "PORTAL_DOMAIN=siasky.net\nSERVER_DOMAIN=\nSKYNET_PORTAL_API=https://siasky.net\nSKYNET_SERVER_API=https://eu-dc-1.siasky.net\nEMAIL_ADDRESS=email@example.com\nSIA_WALLET_PASSWORD=\nHSD_API_KEY=${HSD_API_KEY}\nCLOUDFLARE_AUTH_TOKEN=\nAWS_ACCESS_KEY_ID=\nAWS_SECRET_ACCESS_KEY=\nPORTAL_NAME=\DISCORD_WEBHOOK_URL=\nDISCORD_MENTION_USER_ID=\nDISCORD_MENTION_ROLE_ID=\n" > /home/user/skynet-webportal/.env
+    printf "PORTAL_DOMAIN=siasky.net\nSERVER_DOMAIN=\nSKYNET_PORTAL_API=https://siasky.net\nSKYNET_SERVER_API=https://eu-dc-1.siasky.net\nEMAIL_ADDRESS=email@example.com\nSIA_WALLET_PASSWORD=\nHSD_API_KEY=${HSD_API_KEY}\nCLOUDFLARE_AUTH_TOKEN=\nAWS_ACCESS_KEY_ID=\nAWS_SECRET_ACCESS_KEY=\nDISCORD_WEBHOOK_URL=\nDISCORD_MENTION_USER_ID=\nDISCORD_MENTION_ROLE_ID=\n" > /home/user/skynet-webportal/.env
 fi
 
 # Start docker container with nginx and client

--- a/setup-scripts/support/sia.env
+++ b/setup-scripts/support/sia.env
@@ -6,7 +6,6 @@ SIA_WALLET_PASSWORD=""
 
 # portal specific environment variables
 API_PORT="9980"
-PORTAL_NAME=""
 
 # discord integration
 DISCORD_WEBHOOK_URL=""


### PR DESCRIPTION
removed last traces of `PORTAL_NAME` env var - we can either use `SERVER_UID` for unique server id, `SERVER_DOMAIN` for verbose name (if cluster) or `PORTAL_DOMAIN` on one server setups

Search for all `PORTAL_DOMAIN` occurrences in our repos: https://github.com/search?q=org%3ASkynetLabs+PORTAL_NAME&type=code

part of https://github.com/SkynetLabs/skynet-webportal/issues/718 effort