### PR TITLE
expose /skynet/trustless/basesector

### DIFF
--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -353,7 +353,7 @@ location /skynet/trustless/basesector {
     include /etc/nginx/conf.d/include/proxy-buffer;
     include /etc/nginx/conf.d/include/track-download;
 
-    limit_conn downloads_by_ip 10; # ddos protection: max 100 downloads at a time
+    limit_conn downloads_by_ip 100; # ddos protection: max 100 downloads at a time
 
     # default download rate to unlimited
     set $limit_rate 0;

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -348,6 +348,42 @@ location ~ "^/file/(([a-zA-Z0-9-_]{46}|[a-z0-9]{55})(/.*)?)$" {
     include /etc/nginx/conf.d/include/location-skylink;
 }
 
+location /skynet/trustless/basesector {
+    include /etc/nginx/conf.d/include/cors;
+    include /etc/nginx/conf.d/include/proxy-buffer;
+    include /etc/nginx/conf.d/include/track-download;
+
+    limit_conn downloads_by_ip 10; # ddos protection: max 100 downloads at a time
+
+    # default download rate to unlimited
+    set $limit_rate 0;
+
+    access_by_lua_block {
+        if require("skynet.account").accounts_enabled() then
+            -- check if portal is in authenticated only mode
+            if require("skynet.account").is_access_unauthorized() then
+                return require("skynet.account").exit_access_unauthorized()
+            end
+
+            -- check if portal is in subscription only mode
+            if require("skynet.account").is_access_forbidden() then
+                return require("skynet.account").exit_access_forbidden()
+            end
+
+            -- get account limits of currently authenticated user
+            local limits = require("skynet.account").get_account_limits()
+
+            -- apply download speed limit
+            ngx.var.limit_rate = limits.download
+        end
+    }
+
+    limit_rate_after 512k;
+    limit_rate $limit_rate;
+
+    proxy_pass http://sia:9980;
+}
+
 location /__internal/do/not/use/accounts {
     include /etc/nginx/conf.d/include/cors;
 

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -381,6 +381,7 @@ location /skynet/trustless/basesector {
     limit_rate_after 512k;
     limit_rate $limit_rate;
 
+    proxy_set_header User-Agent: Sia-Agent;
     proxy_pass http://sia:9980;
 }
 


### PR DESCRIPTION
expose /skynet/trustless/basesector

- it's a skylink download endpoint
- it does fall under constraints of accounts
- it is rate limited

ref https://gitlab.com/SkynetLabs/skyd/-/merge_requests/320