### PR TITLE
upgrade nginx linux distro from ubuntu 18 LTS to 20 LTS

### DIFF
--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:1.19.9.1-bionic
+FROM openresty/openresty:1.19.9.1-focal
 
 RUN luarocks install lua-resty-http && \
     luarocks install hasher && \


### PR DESCRIPTION
upgrade openresty (nginx) image to use ubuntu 20 LTS instead of 18 LTS

_compatibility tested on dev server_