### PR TITLE
drop ipv6 support

### DIFF
--- a/docker/nginx/conf.d/server.dnslink.conf
+++ b/docker/nginx/conf.d/server.dnslink.conf
@@ -2,14 +2,12 @@ lua_shared_dict dnslink 10m;
 
 server {
     listen 80 default_server;
-    listen [::]:80 default_server;
     
     include /etc/nginx/conf.d/server/server.dnslink;
 }
 
 server {
     listen 443 default_server;
-    listen [::]:443 default_server;
 
     ssl_certificate     /etc/ssl/local-certificate.crt;
     ssl_certificate_key /etc/ssl/local-certificate.key;

--- a/docker/nginx/conf.d/server.local.conf
+++ b/docker/nginx/conf.d/server.local.conf
@@ -1,7 +1,6 @@
 server {
     # local server - do not expose this port externally
     listen 8000;
-    listen [::]:8000;
 
     # secure traffic by limiting to only local networks
     include /etc/nginx/conf.d/include/local-network-only;

--- a/docker/nginx/conf.d/server/server.account
+++ b/docker/nginx/conf.d/server/server.account
@@ -1,5 +1,4 @@
 listen 443 ssl http2;
-listen [::]:443 ssl http2;
 
 include /etc/nginx/conf.d/include/ssl-settings;
 include /etc/nginx/conf.d/include/init-optional-variables;

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -1,5 +1,4 @@
 listen 443 ssl http2;
-listen [::]:443 ssl http2;
 
 include /etc/nginx/conf.d/include/ssl-settings;
 include /etc/nginx/conf.d/include/init-optional-variables;

--- a/docker/nginx/conf.d/server/server.hns
+++ b/docker/nginx/conf.d/server/server.hns
@@ -1,5 +1,4 @@
 listen 443 ssl http2;
-listen [::]:443 ssl http2;
 
 include /etc/nginx/conf.d/include/ssl-settings;
 include /etc/nginx/conf.d/include/init-optional-variables;

--- a/docker/nginx/conf.d/server/server.http
+++ b/docker/nginx/conf.d/server/server.http
@@ -1,5 +1,4 @@
 listen 80;
-listen [::]:80;
 
 include /etc/nginx/conf.d/include/init-optional-variables;
 

--- a/docker/nginx/conf.d/server/server.skylink
+++ b/docker/nginx/conf.d/server/server.skylink
@@ -1,5 +1,4 @@
 listen 443 ssl http2;
-listen [::]:443 ssl http2;
 
 include /etc/nginx/conf.d/include/ssl-settings;
 include /etc/nginx/conf.d/include/init-optional-variables;


### PR DESCRIPTION
we are getting issues on some providers for not having ipv6 address assigned, since we don't use it anyway we disable it for the time being