### PR TITLE
remove ttl

### DIFF
--- a/docker/caddy/caddy.json.template
+++ b/docker/caddy/caddy.json.template
@@ -25,8 +25,7 @@
                   "dns": {
                     "provider": {
                       "name": "route53"
-                    },
-                    "ttl": "30m"
+                    }
                   }
                 }
               }


### PR DESCRIPTION
removing ttl option because that's not what I hoped it was initially - it doesn't mean the entry will expire after certain time, it just means that the entry can be cached for a specific time which harms us more than helps

> Q. What is the default TTL for the various record types and can I change these values?
>
> The time for which a DNS resolver caches a response is set by a value called the time to live (TTL) associated with every record. Amazon Route 53 does not have a default TTL for any record type. You must always specify a TTL for each record so that caching DNS resolvers can cache your DNS records to the length of time specified through the TTL.