### PR TITLE
feat(dashboard-v2): API access in dev environment

### DIFF
--- a/packages/dashboard-v2/gatsby-config.js
+++ b/packages/dashboard-v2/gatsby-config.js
@@ -1,3 +1,5 @@
+const { createProxyMiddleware } = require("http-proxy-middleware");
+
 module.exports = {
   siteMetadata: {
     title: `Accounts Dashboard`,
@@ -20,4 +22,14 @@ module.exports = {
       __key: "images",
     },
   ],
+  developMiddleware: (app) => {
+    app.use(
+      "/api/",
+      createProxyMiddleware({
+        target: "https://account.siasky.net",
+        secure: false, // Do not reject self-signed certificates.
+        changeOrigin: true,
+      })
+    );
+  },
 };

--- a/packages/dashboard-v2/package.json
+++ b/packages/dashboard-v2/package.json
@@ -23,12 +23,14 @@
     "@fontsource/source-sans-pro": "^4.5.3",
     "gatsby": "^4.6.2",
     "gatsby-plugin-postcss": "^5.7.0",
+    "http-status-codes": "^2.2.0",
     "postcss": "^8.4.6",
     "pretty-bytes": "^6.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0",
     "react-use": "^17.3.2",
+    "swr": "^1.2.2",
     "tailwindcss": "^3.0.23"
   },
   "devDependencies": {
@@ -59,6 +61,7 @@
     "gatsby-plugin-styled-components": "^5.8.0",
     "gatsby-source-filesystem": "^4.6.0",
     "gatsby-transformer-sharp": "^4.6.0",
+    "http-proxy-middleware": "^1.3.1",
     "prettier": "2.5.1",
     "react-is": "^17.0.2",
     "storybook-addon-gatsby": "^0.0.5",

--- a/packages/dashboard-v2/src/layouts/DashboardLayout.js
+++ b/packages/dashboard-v2/src/layouts/DashboardLayout.js
@@ -1,5 +1,8 @@
 import * as React from "react";
 import styled from "styled-components";
+import { SWRConfig } from "swr";
+
+import { authenticatedOnly } from "../lib/swrConfig";
 
 import { PageContainer } from "../components/PageContainer";
 import { NavBar } from "../components/Navbar";
@@ -16,13 +19,15 @@ const Layout = styled.div.attrs({
 const DashboardLayout = ({ children }) => {
   return (
     <>
-      <Layout>
-        <NavBar />
-        <PageContainer>
-          <main className="mt-14">{children}</main>
-        </PageContainer>
-        <Footer />
-      </Layout>
+      <SWRConfig value={authenticatedOnly}>
+        <Layout>
+          <NavBar />
+          <PageContainer>
+            <main className="mt-14">{children}</main>
+          </PageContainer>
+          <Footer />
+        </Layout>
+      </SWRConfig>
     </>
   );
 };

--- a/packages/dashboard-v2/src/lib/swrConfig.js
+++ b/packages/dashboard-v2/src/lib/swrConfig.js
@@ -1,0 +1,31 @@
+import { navigate } from "gatsby";
+import { StatusCodes } from "http-status-codes";
+
+// TODO: portal-aware URL
+const baseUrl = process.env.NODE_ENV !== "production" ? "/api" : "https://account.skynetpro.net/api";
+
+const redirectUnauthenticated = (key) =>
+  fetch(`${baseUrl}/${key}`).then((response) => {
+    if (response.status === StatusCodes.UNAUTHORIZED) {
+      navigate(`/auth/login?return_to=${encodeURIComponent(window.location.href)}`);
+    }
+
+    return response.json();
+  });
+
+const redirectAuthenticated = (key) =>
+  fetch(`${baseUrl}/${key}`).then((response) => {
+    if (response.status === StatusCodes.OK) {
+      navigate(`/`);
+    }
+
+    return response.json();
+  });
+
+export const authenticatedOnly = {
+  fetcher: redirectUnauthenticated,
+};
+
+export const guestsOnly = {
+  fetcher: redirectAuthenticated,
+};

--- a/packages/dashboard-v2/yarn.lock
+++ b/packages/dashboard-v2/yarn.lock
@@ -3320,7 +3320,7 @@
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz#0ea7b61496902b95890dc4c3a116b60cb8dae812"
   integrity sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==
 
-"@types/http-proxy@^1.17.7":
+"@types/http-proxy@^1.17.5", "@types/http-proxy@^1.17.7":
   version "1.17.8"
   resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.8.tgz#968c66903e7e42b483608030ee85800f22d03f55"
   integrity sha512-5kPLG5BKpWYkw/LVOGWpiq3nEVqxiN32rTgI53Sk12/xHFQ2rG3ehI9IO+O3W2QoKeyB92dJkoka8SUm6BX1pA==
@@ -9244,6 +9244,17 @@ http-errors@1.8.1:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.1"
 
+http-proxy-middleware@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-1.3.1.tgz#43700d6d9eecb7419bf086a128d0f7205d9eb665"
+  integrity sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==
+  dependencies:
+    "@types/http-proxy" "^1.17.5"
+    http-proxy "^1.18.1"
+    is-glob "^4.0.1"
+    is-plain-obj "^3.0.0"
+    micromatch "^4.0.2"
+
 http-proxy@^1.18.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
@@ -9252,6 +9263,11 @@ http-proxy@^1.18.1:
     eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
+
+http-status-codes@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-2.2.0.tgz#bb2efe63d941dfc2be18e15f703da525169622be"
+  integrity sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==
 
 http2-wrapper@^1.0.0-beta.5.2:
   version "1.0.3"
@@ -9765,6 +9781,11 @@ is-plain-obj@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
+is-plain-obj@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
+  integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
 
 is-plain-object@5.0.0:
   version "5.0.0"
@@ -14474,6 +14495,11 @@ svgo@^2.7.0:
     csso "^4.2.0"
     picocolors "^1.0.0"
     stable "^0.1.8"
+
+swr@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-1.2.2.tgz#6cae09928d30593a7980d80f85823e57468fac5d"
+  integrity sha512-ky0BskS/V47GpW8d6RU7CPsr6J8cr7mQD6+do5eky3bM0IyJaoi3vO8UhvrzJaObuTlGhPl2szodeB2dUd76Xw==
 
 symbol-observable@^1.0.4:
   version "1.2.0"


### PR DESCRIPTION
## Overview

* Goal here is to have access to the APIs despite CORS (we're starting a proxy server along with `gatsby develop`)
* Proxy is targeting prod as agreed with @kwypchlo, but I'll change it as soon as possible (dev servers are not too stable at the moment)
* There is no way to authenticate here yet (I just manually created a cookie in the browser and it's sufficient for me to continue coding for now)