### PR TITLE
Revert "switch accounts service to docker image"

### DIFF
--- a/docker-compose.accounts.yml
+++ b/docker-compose.accounts.yml
@@ -20,7 +20,11 @@ services:
       - ACCOUNTS_LIMIT_ACCESS=${ACCOUNTS_LIMIT_ACCESS:-authenticated} # default to authenticated access only
 
   accounts:
-    image: skynetlabs/skynet-accounts
+    build:
+      context: ./docker/accounts
+      dockerfile: Dockerfile
+      args:
+        branch: main
     container_name: accounts
     restart: unless-stopped
     logging: *default-logging

--- a/docker/accounts/Dockerfile
+++ b/docker/accounts/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.16.7
+LABEL maintainer="SkynetLabs <devs@siasky.net>"
+
+ENV GOOS linux
+ENV GOARCH amd64
+
+ARG branch=main
+
+WORKDIR /root
+
+RUN git clone --single-branch --branch ${branch} https://github.com/SkynetLabs/skynet-accounts.git && \
+    cd skynet-accounts && \
+    go mod download && \
+    make release
+
+ENV SKYNET_DB_HOST="localhost"
+ENV SKYNET_DB_PORT="27017"
+ENV SKYNET_DB_USER="username"
+ENV SKYNET_DB_PASS="password"
+ENV SKYNET_ACCOUNTS_PORT=3000
+
+ENTRYPOINT ["skynet-accounts"]


### PR DESCRIPTION
Reverts SkynetLabs/skynet-webportal#1769

Temporary revert until we have ansible adjusted for this repo.