### PR TITLE
Expose Blocklist Endpoint

### DIFF
--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -52,6 +52,14 @@ location /skynet/blocklist {
     proxy_pass http://sia:9980/skynet/blocklist;
 }
 
+location /skynet/portal/blocklist {
+    include /etc/nginx/conf.d/include/cors;
+
+    proxy_cache skynet;
+    proxy_cache_valid any 15m; # cache portal blocklist for 15 minutes
+    proxy_pass http://blocker:4000/blocklist;
+}
+
 location /skynet/portals {
     include /etc/nginx/conf.d/include/cors;
 

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -60,7 +60,7 @@ location /skynet/portal/blocklist {
     add_header X-Proxy-Cache $upstream_cache_status;
 
     proxy_cache skynet;
-    proxy_cache_valid any 15m; # cache portal blocklist for 15 minutes
+    proxy_cache_valid 200 204 15m; # cache portal blocklist for 15 minutes
     proxy_pass http://blocker:4000/blocklist;
 }
 

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -46,6 +46,8 @@ location /docs {
 location /skynet/blocklist {
     include /etc/nginx/conf.d/include/cors;
 
+    add_header X-Proxy-Cache $upstream_cache_status;
+
     proxy_cache skynet;
     proxy_cache_valid any 1m; # cache blocklist for 1 minute
     proxy_set_header User-Agent: Sia-Agent;
@@ -55,6 +57,8 @@ location /skynet/blocklist {
 location /skynet/portal/blocklist {
     include /etc/nginx/conf.d/include/cors;
 
+    add_header X-Proxy-Cache $upstream_cache_status;
+
     proxy_cache skynet;
     proxy_cache_valid any 15m; # cache portal blocklist for 15 minutes
     proxy_pass http://blocker:4000/blocklist;
@@ -62,6 +66,8 @@ location /skynet/portal/blocklist {
 
 location /skynet/portals {
     include /etc/nginx/conf.d/include/cors;
+
+    add_header X-Proxy-Cache $upstream_cache_status;
 
     proxy_cache skynet;
     proxy_cache_valid any 1m; # cache portals for 1 minute
@@ -71,6 +77,8 @@ location /skynet/portals {
 
 location /skynet/stats {
     include /etc/nginx/conf.d/include/cors;
+
+    add_header X-Proxy-Cache $upstream_cache_status;
 
     proxy_cache skynet;
     proxy_cache_valid any 1m; # cache stats for 1 minute
@@ -96,6 +104,8 @@ location /serverload {
 
 location /skynet/health {
     include /etc/nginx/conf.d/include/cors;
+
+    add_header X-Proxy-Cache $upstream_cache_status;
 
     proxy_cache skynet;
     proxy_cache_key $request_uri; # use whole request uri (uri + args) as cache key


### PR DESCRIPTION
# PULL REQUEST

## Overview
Add location `location /skynet/portal/blocklist` to expose the blocker endpoint.
Tested, and currently still deployed, on `dev1`.

This endpoint exposes the "blocklist" which is kept in the mongo database. It exposes more information than the skyd blocklist, such as tags, and people can paginate through it. It's necessary for the syncing feature, syncing blocklists between portals.

## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
N/A