### PR TITLE
redirect sdk docs to sdk.skynetlabs.com

### DIFF
--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -21,7 +21,7 @@ client_max_body_size 128k;
 rewrite ^/portals /skynet/portals permanent;
 rewrite ^/stats /skynet/stats permanent;
 rewrite ^/skynet/blacklist /skynet/blocklist permanent;
-rewrite ^/docs https://sdk.skynetlabs.com permanent;
+rewrite ^/docs(?:/(.*))?$ https://sdk.skynetlabs.com/$1 permanent;
 
 location / {
     include /etc/nginx/conf.d/include/cors;

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -21,6 +21,7 @@ client_max_body_size 128k;
 rewrite ^/portals /skynet/portals permanent;
 rewrite ^/stats /skynet/stats permanent;
 rewrite ^/skynet/blacklist /skynet/blocklist permanent;
+rewrite ^/docs https://sdk.skynetlabs.com permanent;
 
 location / {
     include /etc/nginx/conf.d/include/cors;
@@ -37,10 +38,6 @@ location / {
 
 location @fallback {
     proxy_pass http://website:9000;
-}
-
-location /docs {
-    proxy_pass https://skynetlabs.github.io/skynet-docs;
 }
 
 location /skynet/blocklist {


### PR DESCRIPTION
redirect /docs portal endpoint (ie. https://siasky.net/docs) to https://sdk.skynetlabs.com

- works with static subpages like https://siasky.net/docs/v4 => https://sdk.skynetlabs.com/v4
- works with trailing slash or without it ie https://siasky.net/docs or https://siasky.net/docs/