### PR TITLE
Revert "use skynet to load our homepage"

### DIFF
--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -26,17 +26,6 @@ rewrite ^/docs(?:/(.*))?$ https://sdk.skynetlabs.com/$1 permanent;
 location / {
     include /etc/nginx/conf.d/include/cors;
 
-    set $skylink "0404dsjvti046fsua4ktor9grrpe76erq9jot9cvopbhsvsu76r4r30";
-    set $path $uri;
-    set $internal_no_limits "true";
-
-    include /etc/nginx/conf.d/include/location-skylink;
-
-    proxy_intercept_errors on;
-    error_page 400 404 490 500 502 503 504 =200 @fallback;
-}
-
-location @fallback {
     proxy_pass http://website:9000;
 }
 

--- a/packages/health-check/src/checks/critical.js
+++ b/packages/health-check/src/checks/critical.js
@@ -89,14 +89,6 @@ async function handshakeSubdomainCheck(done) {
   return done(await genericAccessCheck("hns_via_subdomain", url));
 }
 
-// websiteSkylinkCheck returns the result of accessing siasky.net website through skylink
-async function websiteSkylinkCheck(done) {
-  const websiteSkylink = "AQBG8n_sgEM_nlEp3G0w3vLjmdvSZ46ln8ZXHn-eObZNjA";
-  const url = await skynetClient.getSkylinkUrl(websiteSkylink, { subdomain: true });
-
-  return done(await genericAccessCheck("website_skylink", url));
-}
-
 // accountWebsiteCheck returns the result of accessing account dashboard website
 async function accountWebsiteCheck(done) {
   const url = `https://account.${process.env.PORTAL_DOMAIN}/auth/login`;
@@ -228,7 +220,6 @@ const checks = [
   skydConfigCheck,
   uploadCheck,
   websiteCheck,
-  websiteSkylinkCheck,
   downloadCheck,
   skylinkSubdomainCheck,
   handshakeSubdomainCheck,


### PR DESCRIPTION
This reverts commit ffb1e499b9c996dd1075c2b4778384f39f49101e.

- website fallback is broken if skyd is not responsive https://github.com/SkynetLabs/skynet-webportal/issues/1372
- different portal operators have different website needs, defaulting to a skylink that gets deployed when skynetlabs deploys new version is not wanted
- there was no easy way to override the skylink and go with custom website container without changing nginx configuration
- merging changes to master meant that all portals get new version of website rolled out immediately and we already had issues with website and api mismatch - website should roll out with api changes
- version of the website from skylink and version of the website could have been mismatched and fallback, even if working properly would cause different versions to be served
- removing skylink also makes it a little bit easier to produce different versions of website for our usage on new pro and free clusters

closes https://github.com/SkynetLabs/skynet-webportal/issues/1372