### PR TITLE
fix health checks working with root domain skylink and hns redirects

### DIFF
--- a/packages/health-check/src/checks/critical.js
+++ b/packages/health-check/src/checks/critical.js
@@ -201,7 +201,11 @@ async function genericAccessCheck(name, url) {
   const data = { up: false, url };
 
   try {
-    const response = await got(url, { headers: { cookie: `nocache=true;${authCookie}` } });
+    const cookie = `nocache=true;${authCookie}`;
+    const response = await got(url, {
+      headers: { cookie },
+      hooks: { beforeRedirect: [(options) => (options.headers.cookie = cookie)] },
+    });
 
     data.statusCode = response.statusCode;
     data.up = true;

--- a/packages/health-check/src/checks/extended.js
+++ b/packages/health-check/src/checks/extended.js
@@ -1023,13 +1023,27 @@ function fileEndpointCheck(done) {
 }
 
 // check whether hns/note-to-self would properly redirect to note-to-self/
-function hnsEndpointDirectoryRedirect(done) {
+function skylinkRootDomainEndpointRedirect(done) {
   const expected = {
-    name: "hns endpoint directory redirect",
-    skylink: "hns/note-to-self",
-    statusCode: 308,
+    name: "skylink root domain endpoint redirect",
+    skylink: "AACogzrAimYPG42tDOKhS3lXZD8YvlF8Q8R17afe95iV2Q",
+    statusCode: 301,
     headers: {
-      location: "note-to-self/",
+      location: `https://000ah0pqo256c3orhmmgpol19dslep1v32v52v23ohqur9uuuuc9bm8.${process.env.PORTAL_DOMAIN}`,
+    },
+  };
+
+  skylinkVerification(done, expected, { followRedirect: false });
+}
+
+// check whether hns/note-to-self would properly redirect to note-to-self/
+function hnsRootDomainEndpointRedirect(done) {
+  const expected = {
+    name: "hns root domain endpoint redirect",
+    skylink: "hns/note-to-self",
+    statusCode: 301,
+    headers: {
+      location: `https://note-to-self.hns.${process.env.PORTAL_DOMAIN}`,
     },
   };
 
@@ -1136,7 +1150,12 @@ async function skylinkVerification(done, expected, { followRedirect = true, meth
 
   try {
     const query = `https://${process.env.PORTAL_DOMAIN}/${expected.skylink}`;
-    const response = await got[method](query, { followRedirect, headers: { cookie: `nocache=true;${authCookie}` } });
+    const cookie = `nocache=true;${authCookie}`;
+    const response = await got[method](query, {
+      followRedirect,
+      headers: { cookie },
+      hooks: { beforeRedirect: [(options) => (options.headers.cookie = cookie)] },
+    });
     const entry = { ...details, up: true, statusCode: response.statusCode, time: calculateElapsedTime(time) };
     const info = {};
 
@@ -1237,7 +1256,8 @@ module.exports = [
   // uniswapHNSRedirectCheck,
   uniswapHNSResolverCheck,
   uniswapHNSResolverRedirectCheck,
-  hnsEndpointDirectoryRedirect,
+  skylinkRootDomainEndpointRedirect,
+  hnsRootDomainEndpointRedirect,
   skappSkySend,
   skappNoteToSelf,
   skappUniswap,


### PR DESCRIPTION
The library that we use in health checks - [got](https://www.npmjs.com/package/got), on a redirect made to a different hostname [clears some headers](https://github.com/sindresorhus/got/blob/main/source/core/index.ts#L774-L795) - namely "host", "cookie", "authorization", "username" and "password". Since the change introduced in https://github.com/SkynetLabs/skynet-webportal/pull/1831 and https://github.com/SkynetLabs/skynet-webportal/pull/1832 redirects skylinks and handshake domains from root domain api to subdomain level api, hostname is changed and previously set headers are cleared. We need to add them back in `beforeRedirect` hook. 

This issue is specific to [got](https://www.npmjs.com/package/got) and does not affect normal browser behaviour that attaches cookie to every matching request. Also this would not be an issue with api keys either because we're using custom "Skynet-Api-Key` header that wouldn't be cleared by the aforementioned piece of code.