### PR TITLE
hotfix: add missing cors headers

### DIFF
--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -334,6 +334,8 @@ location /skynet/resolve {
 }
 
 location ~ "^/(([a-zA-Z0-9-_]{46}|[a-z0-9]{55})(/.*)?)$" {
+    include /etc/nginx/conf.d/include/cors;
+    
     set $skylink $2;
     set $path $3;
 


### PR DESCRIPTION
root /skylink endpoint is missing cors headers that were before included in a different include file

it is causing issues all over skapps and should be treated as immediate hotfix

can be tested for example at https://homescreen.hns.dev3.siasky.dev/ vs https://homescreen.hns.skynetpro.net/ (not loading apps on homescreen)