### PR TITLE
Request /user/limits in bytes.

### DIFF
--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -177,13 +177,13 @@ location /skynet/registry/subscription {
             local httpc = require("resty.http").new()
 
             -- fetch account limits and set download bandwidth and registry delays accordingly
-            local res, err = httpc:request_uri("http://10.10.10.70:3000/user/limits", {
+            local res, err = httpc:request_uri("http://10.10.10.70:3000/user/limits?unit=byte", {
                 headers = { ["Cookie"] = "skynet-jwt=" .. ngx.var.skynet_jwt }
             })
 
             -- fail gracefully in case /user/limits failed
             if err or (res and res.status ~= ngx.HTTP_OK) then
-                ngx.log(ngx.ERR, "Failed accounts service request /user/limits: ", err or ("[HTTP " .. res.status .. "] " .. res.body))
+                ngx.log(ngx.ERR, "Failed accounts service request /user/limits?unit=byte: ", err or ("[HTTP " .. res.status .. "] " .. res.body))
             elseif res and res.status == ngx.HTTP_OK then
                 local json = require('cjson')
                 local limits = json.decode(res.body)
@@ -267,10 +267,10 @@ location /skynet/tus {
             if require("skynet.account").is_access_forbidden() then
                 return require("skynet.account").exit_access_forbidden()
             end
-            
+
             -- get account limits of currently authenticated user
             local limits = require("skynet.account").get_account_limits()
-        
+
             -- apply upload size limits
             ngx.req.set_header("SkynetMaxUploadSize", limits.maxUploadSize)
         end

--- a/docker/nginx/libs/skynet/account.lua
+++ b/docker/nginx/libs/skynet/account.lua
@@ -43,15 +43,15 @@ function _M.get_account_limits()
 
     if ngx.var.account_limits == "" then
         local httpc = require("resty.http").new()
-        
+
         -- 10.10.10.70 points to accounts service (alias not available when using resty-http)
-        local res, err = httpc:request_uri("http://10.10.10.70:3000/user/limits", {
+        local res, err = httpc:request_uri("http://10.10.10.70:3000/user/limits?unit=byte", {
             headers = { ["Cookie"] = "skynet-jwt=" .. ngx.var.skynet_jwt }
         })
-        
+
         -- fail gracefully in case /user/limits failed
         if err or (res and res.status ~= ngx.HTTP_OK) then
-            ngx.log(ngx.ERR, "Failed accounts service request /user/limits: ", err or ("[HTTP " .. res.status .. "] " .. res.body))
+            ngx.log(ngx.ERR, "Failed accounts service request /user/limits?unit=byte: ", err or ("[HTTP " .. res.status .. "] " .. res.body))
             ngx.var.account_limits = cjson.encode(anon_limits)
         elseif res and res.status == ngx.HTTP_OK then
             ngx.var.account_limits = res.body


### PR DESCRIPTION
# PULL REQUEST

## Overview

Nginx needs its speed limits in bytes/s but everyone else expects them to be in bits/s.
This PR adds a query param that will request from accounts to return the limits in bytes and not bits. After this is merged we can deploy a change in accounts which will respond in bits when this param is not set and in bytes when it is.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
