### PR TITLE
return buffer values to default

### DIFF
--- a/docker/nginx/conf.d/include/location-hns
+++ b/docker/nginx/conf.d/include/location-hns
@@ -1,4 +1,3 @@
-include /etc/nginx/conf.d/include/proxy-buffer;
 include /etc/nginx/conf.d/include/proxy-pass-internal;
 include /etc/nginx/conf.d/include/portal-access-check;
 

--- a/docker/nginx/conf.d/include/location-skylink
+++ b/docker/nginx/conf.d/include/location-skylink
@@ -1,5 +1,4 @@
 include /etc/nginx/conf.d/include/cors;
-include /etc/nginx/conf.d/include/proxy-buffer;
 include /etc/nginx/conf.d/include/track-download;
 
 limit_conn downloads_by_ip 100; # ddos protection: max 100 downloads at a time

--- a/docker/nginx/conf.d/include/proxy-buffer
+++ b/docker/nginx/conf.d/include/proxy-buffer
@@ -1,5 +1,0 @@
-# if you are expecting large headers (ie. Skynet-Skyfile-Metadata), tune these values to your needs
-# read more: https://www.getpagespeed.com/server-setup/nginx/tuning-proxy_buffer_size-in-nginx
-proxy_buffer_size 4096k;
-proxy_buffers 64 256k;
-proxy_busy_buffers_size 4096k; # at least as high as proxy_buffer_size

--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -352,7 +352,6 @@ location ~ "^/file/(([a-zA-Z0-9-_]{46}|[a-z0-9]{55})(/.*)?)$" {
 
 location /skynet/trustless/basesector {
     include /etc/nginx/conf.d/include/cors;
-    include /etc/nginx/conf.d/include/proxy-buffer;
     include /etc/nginx/conf.d/include/track-download;
 
     limit_conn downloads_by_ip 100; # ddos protection: max 100 downloads at a time


### PR DESCRIPTION
- originally proxy_buffer_size was increased so that we could fit header with a lot of metadata from Skynet-Metadata header - this is not the case any more and we're fine with regular size headers - default is 4k and we're using roughly 1k on regular skylink with image
- seems like other settings that we had here were slowing down initial video playback, with those removed TTFB is a lot faster, even without tuning it to our needs - I tried some different configurations and default seemed good enough so I can't find a reason to customise those, we would need better performance testing set up