### PR TITLE
insert snippet for docker image developement builds

### DIFF
--- a/docker-compose.abuse-scanner.yml
+++ b/docker-compose.abuse-scanner.yml
@@ -8,6 +8,8 @@ x-logging: &default-logging
 
 services:
   abuse-scanner:
+    # uncomment "build" and comment out "image" to build from sources
+    # build: https://github.com/SkynetLabs/abuse-scanner.git#main
     image: skynetlabs/abuse-scanner
     container_name: abuse-scanner
     restart: unless-stopped

--- a/docker-compose.blocker.yml
+++ b/docker-compose.blocker.yml
@@ -13,6 +13,8 @@ services:
       - BLOCKER_PORT=4000
 
   blocker:
+    # uncomment "build" and comment out "image" to build from sources
+    # build: https://github.com/SkynetLabs/blocker.git#main
     image: skynetlabs/blocker
     container_name: blocker
     restart: unless-stopped

--- a/docker-compose.malware-scanner.yml
+++ b/docker-compose.malware-scanner.yml
@@ -26,6 +26,8 @@ services:
         ipv4_address: 10.10.10.100
 
   malware-scanner:
+    # uncomment "build" and comment out "image" to build from sources
+    # build: https://github.com/SkynetLabs/malware-scanner.git#main
     image: skynetlabs/malware-scanner
     container_name: malware-scanner
     restart: unless-stopped


### PR DESCRIPTION
With images for some of our services replacing local dockerfile builds, we lost an option to run a specific branch of that service. The use case of that is for example when skynet-accounts creates a branch with new feature and would like to have it deployed and tested on a dev server before merging in. Turns out docker compose [supports](https://github.com/docker/compose/pull/2430) git url in "build" key and it would pull specific branch of that repository and use it to build the image locally. 