### PR TITLE
ensure portal and server api headers on dnslink server

### DIFF
--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -16,6 +16,7 @@ COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
 CMD [ "bash", "-c", \
       "./mo < /etc/nginx/conf.d.templates/server.account.conf > /etc/nginx/conf.d/server.account.conf ; \
        ./mo < /etc/nginx/conf.d.templates/server.api.conf > /etc/nginx/conf.d/server.api.conf; \
+       ./mo < /etc/nginx/conf.d.templates/server.dnslink.conf > /etc/nginx/conf.d/server.dnslink.conf; \
        ./mo < /etc/nginx/conf.d.templates/server.hns.conf > /etc/nginx/conf.d/server.hns.conf; \
        ./mo < /etc/nginx/conf.d.templates/server.skylink.conf > /etc/nginx/conf.d/server.skylink.conf ; \
        while :; do sleep 6h & wait ${!}; /usr/local/openresty/bin/openresty -s reload; done & \

--- a/docker/nginx/conf.d.templates/server.dnslink.conf
+++ b/docker/nginx/conf.d.templates/server.dnslink.conf
@@ -12,5 +12,14 @@ server {
     ssl_certificate     /etc/ssl/local-certificate.crt;
     ssl_certificate_key /etc/ssl/local-certificate.key;
 
+    set_by_lua_block $skynet_portal_domain { return "{{PORTAL_DOMAIN}}" }
+    set_by_lua_block $skynet_server_domain {
+        -- fall back to portal domain if server domain is not defined
+        if "{{SERVER_DOMAIN}}" == "" then
+            return "{{PORTAL_DOMAIN}}"
+        end
+        return "{{SERVER_DOMAIN}}"
+    }
+
     include /etc/nginx/conf.d/server/server.dnslink;
 }


### PR DESCRIPTION
Fixes missing skynet-server-api and skynet-portal-api headers on dnslink server.

closes https://github.com/SkynetLabs/skynet-webportal/issues/1946

verification: https://homescreen-beta.app/ - skynet-server-api and skynet-portal-api headers are available