### PR TITLE
skip health checks if container is not running

### DIFF
--- a/setup-scripts/bot_utils.py
+++ b/setup-scripts/bot_utils.py
@@ -32,6 +32,12 @@ sc_precision = 10**24
 # Environment variable globals
 setup_done = False
 
+# get docker container id and return None if container not found
+def get_docker_container_id(container_name):
+    docker_cmd = "docker ps -q -f name=" + container_name
+    output = subprocess.check_output(docker_cmd, shell=True).decode("utf-8")
+    return None if output == "" else output
+
 
 # find out local siad ip by inspecting its docker container
 def get_docker_container_ip(container_name):

--- a/setup-scripts/bot_utils.py
+++ b/setup-scripts/bot_utils.py
@@ -32,6 +32,7 @@ sc_precision = 10**24
 # Environment variable globals
 setup_done = False
 
+
 # get docker container id and return None if container not found
 def get_docker_container_id(container_name):
     docker_cmd = "docker ps -q -f name=" + container_name

--- a/setup-scripts/health-checker.py
+++ b/setup-scripts/health-checker.py
@@ -10,7 +10,7 @@ import traceback
 from datetime import datetime, timedelta
 
 import requests
-from bot_utils import setup, send_msg, get_docker_container_ip
+from bot_utils import setup, send_msg, get_docker_container_id, get_docker_container_ip
 
 """
 health-checker reads the /health-check endpoint of the portal and dispatches
@@ -134,6 +134,12 @@ async def check_disk():
 # check_health checks /health-check endpoint and reports recent issues
 async def check_health():
     print("\nChecking portal health status...")
+
+    # do not try to run health checks if health-check container does not exist
+    # possible use case is fresh or taken down server that has only skyd running
+    if not get_docker_container_id("health-check"):
+        print("Container health-check not found - skipping health checks")
+        return
 
     try:
         endpoint = "http://{}:{}".format(get_docker_container_ip("health-check"), 3100)


### PR DESCRIPTION
Adds new function `get_docker_container_id` that returns a container id string (ie. ) or `None` if container is not found. It does not check whether container is running or restarting so it's a great way to check whether container has been started at the very least. In our use case, we should not try to run health checks if health-check container is not running - we've been spammed by "Could not get health check service endpoint api!" on servers that are on a takedown list because they only run skyd and mongo.