### PR TITLE
Rename s3 backup dirs

### DIFF
--- a/scripts/backup-aws-s3.sh
+++ b/scripts/backup-aws-s3.sh
@@ -13,11 +13,13 @@ ENV_VARIABLES=("AWS_ACCESS_KEY_ID" "AWS_SECRET_ACCESS_KEY" "PORTAL_DOMAIN" "SERV
 for ENV_VARIABLE in "${ENV_VARIABLES[@]}"; do
     ENV_VARIABLE_VALUE=$(grep -v '^#' /home/user/skynet-webportal/.env | grep ${ENV_VARIABLE} || true)
     if test -z "${ENV_VARIABLE_VALUE}"; then
-        if $ENV_VARIABLE ~= "SERVER_DOMAIN"; then
+        # all variables except SERVER_DOMAIN are required
+        if [ "${ENV_VARIABLE}" != "SERVER_DOMAIN" ]; then
             echo "Environment variable ${ENV_VARIABLE} is not set" && exit 1
         fi
+    else
+        export ${ENV_VARIABLE_VALUE}
     fi
-    export ${ENV_VARIABLE_VALUE}
 done
 
 # create bucket skynet-backup-[portaldomain] (replace dots with dashes and strip anything other than alnum)
@@ -30,10 +32,16 @@ if test -z "${SERVER_DOMAIN}"; then
     SERVER_PREFIX=$(echo ${SERVER_UID} | tr  '.'  '-' | tr -cd '[[:alnum:]]-')
 else
     # use both uid and server domain if available (replace dots with dashes and strip anything other than alnum)
-    SERVER_PREFIX=$(echo ${SERVER_UID}-${SERVER_DOMAIN} | tr  '.'  '-' | tr -cd '[[:alnum:]]-')
+    SERVER_PREFIX=$(echo ${SERVER_DOMAIN}-${SERVER_UID} | tr  '.'  '-' | tr -cd '[[:alnum:]]-')
+    SERVER_PREFIX_LEGACY=$(echo ${SERVER_UID}-${SERVER_DOMAIN} | tr  '.'  '-' | tr -cd '[[:alnum:]]-')
 fi
 
 aws s3api create-bucket --acl private --bucket ${BUCKET_NAME}
+
+# move old backup dir to new location if legacy backup path exists
+if test -n "${SERVER_PREFIX_LEGACY}"; then
+    aws s3 mv --recursive s3://${BUCKET_NAME}/${SERVER_PREFIX_LEGACY} s3://${BUCKET_NAME}/${SERVER_PREFIX} 
+fi
 
 # sync all nginx logs
 mkdir -p /home/user/skynet-webportal/docker/data/nginx/logs # ensure path exists


### PR DESCRIPTION
- fixes issue where backups would not run for servers without defined `SERVER_DOMAIN`
- renames server backup subdirectory from `[server uid]-[server domain]` to `[server domain]-[server uid]` to improve readability of the list and enable sorting of directories
- added `s3 mv` script that initially moves `[server uid]-[server domain]` to `[server domain]-[server uid]` if it exists


tested on cases
- SERVER_DOMAIN doesn't exist
- SERVER_DOMAIN exists and is empty
- SERVER_DOMAIN exists and has value
- legacy directory exists
- legacy directory doesn't exist (already moved)