### PR TITLE
add skynet-sponsor-key functionality

### DIFF
--- a/docker/nginx/conf.d/server/server.dnslink
+++ b/docker/nginx/conf.d/server/server.dnslink
@@ -5,6 +5,7 @@ location / {
     set $path $uri;
 
     rewrite_by_lua_block {
+        local cjson = require("cjson")
         local cache = ngx.shared.dnslink
         local cache_value = cache:get(ngx.var.host)
 
@@ -28,13 +29,23 @@ location / {
                     ngx.exit(ngx.status)
                 end
             else
-                ngx.var.skylink = res.body
+                local resolved = cjson.decode(res.body)
+
+                ngx.var.skylink = resolved.skylink
+                if resolved.sponsor then
+                    ngx.req.set_header("Skynet-Api-Key", resolved.sponsor)
+                end
 
                 local cache_ttl = 300 -- 5 minutes cache expire time
-                cache:set(ngx.var.host, ngx.var.skylink, cache_ttl)
+                cache:set(ngx.var.host, res.body, cache_ttl)
             end
         else
-            ngx.var.skylink = cache_value
+            local resolved = cjson.decode(cache_value)
+
+            ngx.var.skylink = resolved.skylink
+            if resolved.sponsor then
+                ngx.req.set_header("Skynet-Api-Key", resolved.sponsor)
+            end
         end
 
         ngx.var.skylink = require("skynet.skylink").parse(ngx.var.skylink)


### PR DESCRIPTION
Includes an option to pass a sponsor key for portals requiring authentication to work with dnslink. The sponsor token is a special version of an api key that you can generate in your account dashboard that allows to list specific skylinks that it covers. Once sponsor key is generated, you should add new TXT _dnslink (you will have 2 TXT _dnslink entries now) dns entry to your existing dnslink enabled domain that looks like this `skynet-sponsor-key=<your-sponsor-key-here>`.

Note: exposing sponsor key in dns entry means that it is publicly available, anyone will be able to query dns records and look it up but it will only work with the set of skylinks that you enabled when creating it - also you can always revoke it in your user dashboard panel