### PR TITLE
remove max body size constraint on tus endpoint

### DIFF
--- a/docker/nginx/conf.d/server/server.api
+++ b/docker/nginx/conf.d/server/server.api
@@ -241,8 +241,8 @@ location /skynet/tus {
     limit_conn upload_conn 5;
     limit_conn upload_conn_rl 1;
 
-    # TUS chunks size is 40M + leaving 10M of breathing room
-    client_max_body_size 50M;
+    # Do not limit body size in nginx, skyd will reject early on too large upload
+    client_max_body_size 0;
 
     # Those timeouts need to be elevated since skyd can stall reading
     # data for a while when overloaded which would terminate connection


### PR DESCRIPTION
set `client_max_body_size` to `0` to remove the max body size constraint on uploads on this endpoint because skyd will read `SkynetMaxUploadSize` header and reject early if that's too large