### PR TITLE
update dashboard-v2 ip

### DIFF
--- a/docker-compose.accounts.yml
+++ b/docker-compose.accounts.yml
@@ -92,7 +92,7 @@ services:
       - ./docker/data/dashboard-v2/public:/usr/app/public
     networks:
       shared:
-        ipv4_address: 10.10.10.90
+        ipv4_address: 10.10.10.86
     expose:
       - 9000
     depends_on:


### PR DESCRIPTION
change ip to dashboard + 1 because 10.10.10.90 is already taken by different service
https://github.com/SkynetLabs/skynet-webportal/blob/master/docker-compose.jaeger.yml#L41