### PR TITLE
pass skylink from request context to /user/limits

### DIFF
--- a/docker/nginx/libs/skynet/account.lua
+++ b/docker/nginx/libs/skynet/account.lua
@@ -76,9 +76,16 @@ function _M.get_account_limits()
 
     if ngx.var.account_limits == "" then
         local httpc = require("resty.http").new()
+        local uri = "http://10.10.10.70:3000/user/limits"
+
+        -- include skylink if it is available in the context of request
+        -- todo: this should not rely on skylink variable to be defined
+        if ngx.var.skylink ~= nil and ngx.var.skylink ~= "" then
+            uri = uri .. "/" .. ngx.var.skylink
+        end
 
         -- 10.10.10.70 points to accounts service (alias not available when using resty-http)
-        local res, err = httpc:request_uri("http://10.10.10.70:3000/user/limits?unit=byte", {
+        local res, err = httpc:request_uri(uri .. "?unit=byte", {
             headers = auth_headers,
         })
 


### PR DESCRIPTION
When `skylink` variable is set in context of request, use it when requesting limits from /user/limits endpoint.

TODO & DISCLAIMER: that logic only works because the skylink is only set in context where skylink is accessed, unfortunately this assumption is be easy to break if someone without knowledge of this changes an endpoint that otherwise doesn't operate in context of skylink (like registry endpoint) and uses skylink variable for something else - this functionality should be rewritten when refactoring nginx account pieces with tests. (issue here https://github.com/SkynetLabs/skynet-webportal/issues/2011 )