### PR TITLE
Mongo: ShardingTaskExecutorPoolMinSize=10

### DIFF
--- a/docker-compose.mongodb.yml
+++ b/docker-compose.mongodb.yml
@@ -15,7 +15,7 @@ services:
 
   mongo:
     image: mongo:4.4.1
-    command: --keyFile=/data/mgkey --replSet=${SKYNET_DB_REPLICASET:-skynet}
+    command: --keyFile=/data/mgkey --replSet=${SKYNET_DB_REPLICASET:-skynet} --setParameter ShardingTaskExecutorPoolMinSize=10
     container_name: mongo
     restart: unless-stopped
     logging: *default-logging


### PR DESCRIPTION
# PULL REQUEST

## Overview

We are experiencing a large number of these errors, referring to different servers:
```json
{
    "t": {
        "$date": "2022-04-19T13:54:53.216+00:00"
    },
    "s": "I",
    "c": "NETWORK",
    "id": 4712102,
    "ctx": "ReplicaSetMonitor-TaskExecutor",
    "msg": "Host failed in replica set",
    "attr": {
        "replicaSet": "skynet",
        "host": "eu-fin-5.siasky.net:27017",
        "error": {
            "code": 202,
            "codeName": "NetworkInterfaceExceededTimeLimit",
            "errmsg": "Couldn't get a connection within the time limit of 649ms"
        },
        "action": {
            "dropConnections": false,
            "requestImmediateCheck": false,
            "outcome": {
                "host": "eu-fin-5.siasky.net:27017",
                "success": false,
                "errorMessage": "NetworkInterfaceExceededTimeLimit: Couldn't get a connection within the time limit of 649ms"
            }
        }
    }
}
```


Potential solution: https://www.mongodb.com/community/forums/t/mongos-couldnt-get-a-connection-within-the-time-limit/3382/5
Official docs: https://www.mongodb.com/docs/manual/reference/parameters/#mongodb-parameter-param.ShardingTaskExecutorPoolMinSize

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
