### PR TITLE
use dashboard dockerhub image

### DIFF
--- a/docker-compose.accounts.yml
+++ b/docker-compose.accounts.yml
@@ -79,7 +79,9 @@ services:
       - mongo
 
   dashboard-v2:
-    build: packages/dashboard-v2/Dockerfile
+    build:
+      context: .
+      dockerfile: packages/dashboard-v2/Dockerfile
     container_name: dashboard-v2
     restart: unless-stopped
     logging: *default-logging

--- a/docker-compose.accounts.yml
+++ b/docker-compose.accounts.yml
@@ -55,9 +55,11 @@ services:
       - mongo
 
   dashboard:
-    build:
-      context: ./packages/dashboard
-      dockerfile: Dockerfile
+    # uncomment "build" and comment out "image" to build from sources
+    # build:
+    #   context: https://github.com/SkynetLabs/skynet-webportal.git#master
+    #   dockerfile: ./packages/dashboard/Dockerfile
+    image: skynetlabs/dashboard
     container_name: dashboard
     restart: unless-stopped
     logging: *default-logging
@@ -77,9 +79,7 @@ services:
       - mongo
 
   dashboard-v2:
-    build:
-      context: ./packages/dashboard-v2
-      dockerfile: Dockerfile
+    build: packages/dashboard-v2/Dockerfile
     container_name: dashboard-v2
     restart: unless-stopped
     logging: *default-logging

--- a/packages/dashboard-v2/Dockerfile
+++ b/packages/dashboard-v2/Dockerfile
@@ -2,13 +2,17 @@ FROM node:16.14.2-alpine
 
 WORKDIR /usr/app
 
-COPY package.json yarn.lock ./
+COPY packages/dashboard-v2/package.json \
+     packages/dashboard-v2/yarn.lock \
+     ./
 
 RUN yarn --frozen-lockfile
 
-COPY static ./static
-COPY src ./src
-COPY gatsby*.js ./
-COPY postcss.config.js tailwind.config.js ./
+COPY packages/dashboard-v2/static ./static
+COPY packages/dashboard-v2/src ./src
+COPY packages/dashboard-v2/gatsby*.js \
+     packages/dashboard-v2/postcss.config.js \
+     packages/dashboard-v2/tailwind.config.js \
+     ./
 
 CMD ["sh", "-c", "yarn build && yarn serve --host 0.0.0.0 -p 9000"]

--- a/packages/dashboard/Dockerfile
+++ b/packages/dashboard/Dockerfile
@@ -2,14 +2,19 @@ FROM node:16.14.2-alpine
 
 WORKDIR /usr/app
 
-COPY package.json yarn.lock ./
+COPY packages/dashboard/package.json \
+     packages/dashboard/yarn.lock \
+     ./
 
 ENV NEXT_TELEMETRY_DISABLED 1
 RUN yarn --frozen-lockfile
 
-COPY public ./public
-COPY src ./src
-COPY styles ./styles
-COPY .eslintrc.json postcss.config.js tailwind.config.js ./
+COPY packages/dashboard/public ./public
+COPY packages/dashboard/src ./src
+COPY packages/dashboard/styles ./styles
+COPY packages/dashboard/.eslintrc.json \
+     packages/dashboard/postcss.config.js \
+     packages/dashboard/tailwind.config.js \
+     ./
 
 CMD ["sh", "-c", "env | grep -E 'NEXT_PUBLIC|STRIPE|ACCOUNTS' > .env.local && yarn build && yarn start"]


### PR DESCRIPTION
- use dashboard dockerhub image
- prepare dashboard-v2 Dockerfile for image release
  - we will release it as skynetlabs/dashboard but with major version bumped when we're ready to make a switch