### PR TITLE
Point to latest semver release for docker images

### DIFF
--- a/docker-compose.abuse-scanner.yml
+++ b/docker-compose.abuse-scanner.yml
@@ -10,7 +10,7 @@ services:
   abuse-scanner:
     # uncomment "build" and comment out "image" to build from sources
     # build: https://github.com/SkynetLabs/abuse-scanner.git#main
-    image: skynetlabs/abuse-scanner
+    image: skynetlabs/abuse-scanner:0.1.0
     container_name: abuse-scanner
     restart: unless-stopped
     logging: *default-logging

--- a/docker-compose.blocker.yml
+++ b/docker-compose.blocker.yml
@@ -15,7 +15,7 @@ services:
   blocker:
     # uncomment "build" and comment out "image" to build from sources
     # build: https://github.com/SkynetLabs/blocker.git#main
-    image: skynetlabs/blocker
+    image: skynetlabs/blocker:0.1.0
     container_name: blocker
     restart: unless-stopped
     logging: *default-logging

--- a/docker-compose.malware-scanner.yml
+++ b/docker-compose.malware-scanner.yml
@@ -28,7 +28,7 @@ services:
   malware-scanner:
     # uncomment "build" and comment out "image" to build from sources
     # build: https://github.com/SkynetLabs/malware-scanner.git#main
-    image: skynetlabs/malware-scanner
+    image: skynetlabs/malware-scanner:0.1.0
     container_name: malware-scanner
     restart: unless-stopped
     logging: *default-logging


### PR DESCRIPTION
# PULL REQUEST

## Overview
This removes the manual step that was added to our deployment process where we were referencing deploy tags for our sub module repos. 


