### PR TITLE
Fix dashboard-v2 Dockerfile context

### DIFF
--- a/changelog/items/bugs-fixed/fix-context.md
+++ b/changelog/items/bugs-fixed/fix-context.md
@@ -1,0 +1,2 @@
+- Fix `dashboard-v2` Dockerfile context in `docker-compose.accounts.yml` to
+  avoid Ansible deploy (docker compose build) `permission denied` issues.

--- a/docker-compose.accounts.yml
+++ b/docker-compose.accounts.yml
@@ -80,8 +80,8 @@ services:
 
   dashboard-v2:
     build:
-      context: .
-      dockerfile: packages/dashboard-v2/Dockerfile
+      context: ./packages/dashboard-v2
+      dockerfile: Dockerfile
     container_name: dashboard-v2
     restart: unless-stopped
     logging: *default-logging

--- a/packages/dashboard-v2/Dockerfile
+++ b/packages/dashboard-v2/Dockerfile
@@ -2,17 +2,17 @@ FROM node:16.14.2-alpine
 
 WORKDIR /usr/app
 
-COPY packages/dashboard-v2/package.json \
-     packages/dashboard-v2/yarn.lock \
+COPY package.json \
+     yarn.lock \
      ./
 
 RUN yarn --frozen-lockfile
 
-COPY packages/dashboard-v2/static ./static
-COPY packages/dashboard-v2/src ./src
-COPY packages/dashboard-v2/gatsby*.js \
-     packages/dashboard-v2/postcss.config.js \
-     packages/dashboard-v2/tailwind.config.js \
+COPY static ./static
+COPY src ./src
+COPY gatsby*.js \
+     postcss.config.js \
+     tailwind.config.js \
      ./
 
 CMD ["sh", "-c", "yarn build && yarn serve --host 0.0.0.0 -p 9000"]


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR fixes `permission denied` issue during building `dashboard-v2` docker service using Ansible.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
