### PR TITLE
Stop Grace Period

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
         branch: portal-latest
     container_name: sia
     restart: unless-stopped
+    stop_grace_period: 5m
     logging: *default-logging
     environment:
       - SIA_MODULES=gctwra


### PR DESCRIPTION
# PULL REQUEST

## Overview

While investigating a container crash on fileportal.org's stack I noticed in the kernel logs that our skyd container fails to respond in time when a stop signal is sent. By default a docker container has to stop within 10s, if it fails to do so, the docker engine will send a `SIGKILL`

I think we want to configure a grace period of 5m to allow the renter to stop and clean up and shutdown cleanly if this happens.

https://docs.docker.com/compose/compose-file/compose-file-v3/#stop_grace_period

## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
N/A