### PR TITLE
fix dnsmasq versioning in health-check dockerfile

### DIFF
--- a/packages/health-check/Dockerfile
+++ b/packages/health-check/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16.14.2-alpine
 
-RUN apk add --no-cache dnsmasq=2.86-r0
+RUN apk add --no-cache dnsmasq~=2
 
 WORKDIR /usr/app
 


### PR DESCRIPTION
Set more relaxed version of dnsmasq due to alpine apk deleting all non-current versions from repo and pinning it to a strict version like we had before gets outdated pretty often. 

Solution taken from: https://github.com/hadolint/hadolint/issues/204#issuecomment-394103224