### PR TITLE
fix website image running params

### DIFF
--- a/packages/website/Dockerfile
+++ b/packages/website/Dockerfile
@@ -34,4 +34,4 @@ COPY --from=builder /usr/app/public /usr/app/public
 
 EXPOSE 9000
 
-CMD ["http-server", "/usr/app/public", "-s -p 9000"]
+CMD ["http-server", "/usr/app/public", "-s", "-p 9000"]


### PR DESCRIPTION
Fix params of http-server - every param should be split, otherwise they are not passed correctly and website started on default port 8080.