### PR TITLE
Dashboard V2: Fix extraneous tiers on /payments screen

### DIFF
--- a/packages/dashboard-v2/src/contexts/plans/PlansProvider.js
+++ b/packages/dashboard-v2/src/contexts/plans/PlansProvider.js
@@ -19,14 +19,20 @@ const aggregatePlansAndLimits = (plans, limits, { includeFreePlan }) => {
 
   // Decorate each plan with its corresponding limits data, if available.
   if (limits?.length) {
-    return limits.map((limitsDescriptor, index) => {
-      const asssociatedPlan = sortedPlans.find((plan) => plan.tier === index) || {};
+    return limits
+      .map((limitsDescriptor, index) => {
+        const asssociatedPlan = sortedPlans.find((plan) => plan.tier === index);
 
-      return {
-        ...asssociatedPlan,
-        limits: limitsDescriptor || null,
-      };
-    });
+        if (asssociatedPlan) {
+          return {
+            ...asssociatedPlan,
+            limits: limitsDescriptor || null,
+          };
+        }
+
+        return null;
+      })
+      .filter(Boolean);
   }
 
   // If we don't have the limits data yet, set just return the plans.


### PR DESCRIPTION
## Overview
We've been listing tiers which could not be purchased/subscribed to (anonymous & free (on skynetpro)).
This makes sure we only list the tiers (limits) that actually have a plan associated with them.

## Visual Changes
* [Before](https://user-images.githubusercontent.com/3853033/170091799-29a185b2-da8d-4394-8a51-da56605bce23.png)
* [After](https://user-images.githubusercontent.com/3853033/170091710-f01a9331-12ff-47d8-824a-3d11912a3047.png)
