### PR TITLE
skip server_domain check on single server portals

### DIFF
--- a/packages/health-check/bin/cli
+++ b/packages/health-check/bin/cli
@@ -71,7 +71,7 @@ require("yargs/yargs")(process.argv.slice(2))
 
       const entry = {
         date: new Date().toISOString(),
-        checks: (await Promise.all(checks.map((check) => new Promise(check)))).map(middleware),
+        checks: (await Promise.all(checks.map((check) => new Promise(check)))).filter(Boolean).map(middleware),
       };
 
       db.read() // read before writing to make sure no external changes are overwritten

--- a/packages/health-check/src/checks/critical.js
+++ b/packages/health-check/src/checks/critical.js
@@ -122,8 +122,9 @@ async function registryWriteAndReadCheck(done) {
 
 // directServerApiAccessCheck returns the basic server api check on direct server address
 async function directServerApiAccessCheck(done) {
-  if (!process.env.SERVER_DOMAIN) {
-    return done({ up: false, errors: [{ message: "SERVER_DOMAIN env variable not configured" }] });
+  // skip if SERVER_DOMAIN is not set or it equals PORTAL_DOMAIN (single server portals)
+  if (!process.env.SERVER_DOMAIN || process.env.SERVER_DOMAIN === process.env.PORTAL_DOMAIN) {
+    return done();
   }
 
   const [portalAccessCheck, serverAccessCheck] = await Promise.all([


### PR DESCRIPTION
SERVER_DOMAIN can be empty, do not run directServerApiAccessCheck health check if not necessary