### PR TITLE
Don't pass GATSBY_ env vars to dashboard anymore

### DIFF
--- a/docker-compose.accounts.yml
+++ b/docker-compose.accounts.yml
@@ -65,9 +65,6 @@ services:
     logging: *default-logging
     env_file:
       - .env
-    environment:
-      - GATSBY_PORTAL_DOMAIN=${PORTAL_DOMAIN}
-      - GATSBY_STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY}
     volumes:
       - ./docker/data/dashboard/.cache:/usr/app/.cache
       - ./docker/data/dashboard/public:/usr/app/public

--- a/docker-compose.accounts.yml
+++ b/docker-compose.accounts.yml
@@ -59,7 +59,7 @@ services:
     # build:
     #   context: https://github.com/SkynetLabs/webportal-accounts-dashboard.git#main
     #   dockerfile: Dockerfile
-    image: skynetlabs/webportal-accounts-dashboard:1.1.2
+    image: skynetlabs/webportal-accounts-dashboard:2.0.0
     container_name: dashboard
     restart: unless-stopped
     logging: *default-logging


### PR DESCRIPTION
- [x] Update dashboard's image version.

## Overview
* Once https://github.com/SkynetLabs/webportal-accounts-dashboard/pull/48 is released, we can control the env variables used by the app by updating dashboard's repository only.
* This PR will be made `Ready for review` once the one in dashboard's repo is merged and a new image is released.