### PR TITLE
upgrade to handshakeorg/hsd:4.0.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,17 +122,11 @@ services:
       - 9000
 
   handshake:
-    image: skynetlabs/hsd:3.0.1
-    command: --chain-migrate=2 --wallet-migrate=1
+    image: handshakeorg/hsd:4.0.2
+    command: --chain-migrate=3 --no-wallet --compact-tree-on-init --network=main --http-host=0.0.0.0
     container_name: handshake
     restart: unless-stopped
     logging: *default-logging
-    environment:
-      - HSD_HTTP_HOST=0.0.0.0
-      - HSD_NETWORK=main
-      - HSD_PORT=12037
-    env_file:
-      - .env
     volumes:
       - ./docker/data/handshake/.hsd:/root/.hsd
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,7 @@ services:
 
   handshake:
     image: handshakeorg/hsd:4.0.2
-    command: --chain-migrate=3 --no-wallet --compact-tree-on-init --network=main --http-host=0.0.0.0
+    command: --chain-migrate=3 --no-wallet --no-auth --compact-tree-on-init --network=main --http-host=0.0.0.0
     container_name: handshake
     restart: unless-stopped
     logging: *default-logging


### PR DESCRIPTION
- switch to official [handshakeorg/hsd](https://hub.docker.com/r/handshakeorg/hsd) image
- bumps hsd to v4 and adds chain migration option
- disables wallet module since we're not using it
- disables api key auth (we do not expose the api publicly)
- enables outdated tree data compaction on startup (saves around 15G disk space)

tested on siasky.xyz