### PR TITLE
upgrade docker compose to 3.8

### DIFF
--- a/docker-compose.abuse-scanner.yml
+++ b/docker-compose.abuse-scanner.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.8"
 
 x-logging: &default-logging
   driver: json-file

--- a/docker-compose.accounts.yml
+++ b/docker-compose.accounts.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.8"
 
 x-logging: &default-logging
   driver: json-file

--- a/docker-compose.blocker.yml
+++ b/docker-compose.blocker.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.8"
 
 x-logging: &default-logging
   driver: json-file

--- a/docker-compose.jaeger.yml
+++ b/docker-compose.jaeger.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.8"
 
 x-logging: &default-logging
   driver: json-file

--- a/docker-compose.malware-scanner.yml
+++ b/docker-compose.malware-scanner.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.8"
 
 x-logging: &default-logging
   driver: json-file

--- a/docker-compose.mongodb.yml
+++ b/docker-compose.mongodb.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.8"
 
 x-logging: &default-logging
   driver: json-file

--- a/docker-compose.pinner.yml
+++ b/docker-compose.pinner.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.8"
 
 x-logging: &default-logging
   driver: json-file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.8"
 
 x-logging: &default-logging
   driver: json-file


### PR DESCRIPTION
Ansible is generating `docker-compose.override.yml` with 3.8 version (since https://github.com/SkynetLabs/ansible-playbooks/pull/342) and the mismatch in versions between override and other compose files breaks the `./dc` script while ansible deploys work just fine for some reason. Easiest and backwards compatible fix is to bump the version in compose files.

Tested on siasky.xyz.