### PR TITLE
allow relative call to dc script

### DIFF
--- a/dc
+++ b/dc
@@ -5,56 +5,59 @@
 # would use docker-compose with the only difference being that you don't need to specify compose files. For more
 # information you can run `./dc` or `./dc help`.
 
-if [ -f .env ]; then
+# get current working directory of this script
+cwd="$(dirname -- "$0";)";
+
+if [ -f ${cwd}/.env ]; then
   OLD_IFS=$IFS
   IFS=$'\n'
-  for x in $(grep -v '^#.*' .env); do export $x; done
+  for x in $(grep -v '^#.*' ${cwd}/.env); do export $x; done
   IFS=$OLD_IFS
 fi
 
 # include base docker compose file
-COMPOSE_FILES="-f docker-compose.yml"
+COMPOSE_FILES="-f ${cwd}/docker-compose.yml"
 
 for i in $(seq 1 ${#PORTAL_MODULES}); do
   # accounts module - alias "a"
   if [[ ${PORTAL_MODULES:i-1:1} == "a" ]]; then
-    COMPOSE_FILES+=" -f docker-compose.mongodb.yml -f docker-compose.accounts.yml"
+    COMPOSE_FILES+=" -f ${cwd}/docker-compose.mongodb.yml -f ${cwd}/docker-compose.accounts.yml"
   fi
 
   # blocker module - alias "b"
   if [[ ${PORTAL_MODULES:i-1:1} == "b" ]]; then
-    COMPOSE_FILES+=" -f docker-compose.mongodb.yml -f docker-compose.blocker.yml"
+    COMPOSE_FILES+=" -f ${cwd}/docker-compose.mongodb.yml -f ${cwd}/docker-compose.blocker.yml"
   fi
 
   # jaeger module - alias "j"
   if [[ ${PORTAL_MODULES:i-1:1} == "j" ]]; then
-    COMPOSE_FILES+=" -f docker-compose.jaeger.yml"
+    COMPOSE_FILES+=" -f ${cwd}/docker-compose.jaeger.yml"
   fi
 
   # malware-scanner module - alias "s"
   if [[ ${PORTAL_MODULES:i-1:1} == "s" ]]; then
-    COMPOSE_FILES+=" -f docker-compose.blocker.yml -f docker-compose.mongodb.yml -f docker-compose.malware-scanner.yml"
+    COMPOSE_FILES+=" -f ${cwd}/docker-compose.blocker.yml -f ${cwd}/docker-compose.mongodb.yml -f ${cwd}/docker-compose.malware-scanner.yml"
   fi
 
   # mongodb module - alias "m"
   if [[ ${PORTAL_MODULES:i-1:1} == "m" ]]; then
-    COMPOSE_FILES+=" -f docker-compose.mongodb.yml"
+    COMPOSE_FILES+=" -f ${cwd}/docker-compose.mongodb.yml"
   fi
 
   # abuse-scanner module - alias "u"
   if [[ ${PORTAL_MODULES:i-1:1} == "u" ]]; then
-    COMPOSE_FILES+=" -f docker-compose.mongodb.yml -f docker-compose.blocker.yml -f docker-compose.abuse-scanner.yml"
+    COMPOSE_FILES+=" -f ${cwd}/docker-compose.mongodb.yml -f ${cwd}/docker-compose.blocker.yml -f ${cwd}/docker-compose.abuse-scanner.yml"
   fi
 
   # pinner module - alias "p"
   if [[ ${PORTAL_MODULES:i-1:1} == "p" ]]; then
-    COMPOSE_FILES+=" -f docker-compose.mongodb.yml -f docker-compose.pinner.yml"
+    COMPOSE_FILES+=" -f ${cwd}/docker-compose.mongodb.yml -f ${cwd}/docker-compose.pinner.yml"
   fi
 done
 
 # override file if exists
 if [[ -f docker-compose.override.yml ]]; then
-  COMPOSE_FILES+=" -f docker-compose.override.yml"
+  COMPOSE_FILES+=" -f ${cwd}/docker-compose.override.yml"
 fi
 
 docker-compose $COMPOSE_FILES $@

--- a/dc
+++ b/dc
@@ -5,15 +5,13 @@
 # would use docker-compose with the only difference being that you don't need to specify compose files. For more
 # information you can run `./dc` or `./dc help`.
 
-# get current working directory of this script
+# get current working directory of this script and prefix all files with it to
+# be able to call this script from anywhere and not only root directory of
+# skynet-webportal project
 cwd="$(dirname -- "$0";)";
 
-if [ -f ${cwd}/.env ]; then
-  OLD_IFS=$IFS
-  IFS=$'\n'
-  for x in $(grep -v '^#.*' ${cwd}/.env); do export $x; done
-  IFS=$OLD_IFS
-fi
+# get portal modules configuration from .env file (if defined more than once, the last one is used)
+PORTAL_MODULES=$(grep -e "^PORTAL_MODULES=" ${cwd}.env | tail -1 | sed "s/PORTAL_MODULES=//")
 
 # include base docker compose file
 COMPOSE_FILES="-f ${cwd}/docker-compose.yml"


### PR DESCRIPTION
allows calling `dc` from any directory, not only from the root directory of project

**before**
`cd /home/user/skynet-webportal && ./dc` - works
`cd /home/user && ./skynet-webportal/dc` - does not work
`cd /home/user && /home/user/skynet-webportal/dc` - does not work

**after**
`cd /home/user/skynet-webportal && ./dc` - works
`cd /home/user && ./skynet-webportal/dc` - works
`cd /home/user && /home/user/skynet-webportal/dc` - works

this fix is useful for future ansible development