### PR TITLE
do not report from dc when env file does not exist

### DIFF
--- a/dc
+++ b/dc
@@ -11,7 +11,9 @@
 cwd="$(dirname -- "$0";)";
 
 # get portal modules configuration from .env file (if defined more than once, the last one is used)
-PORTAL_MODULES=$(grep -e "^PORTAL_MODULES=" ${cwd}/.env | tail -1 | sed "s/PORTAL_MODULES=//")
+if [[ -f "${cwd}/.env" ]]; then
+  PORTAL_MODULES=$(grep -e "^PORTAL_MODULES=" ${cwd}/.env | tail -1 | sed "s/PORTAL_MODULES=//")
+fi
 
 # include base docker compose file
 COMPOSE_FILES="-f ${cwd}/docker-compose.yml"


### PR DESCRIPTION
dc should not report error when .env does not exist (it just logs error, doesn't really break the script anyway), docker-compose will report on that and exit with proper error code

before
```
➜  skynet-webportal git:(master) ✗ ./dc down
grep: ./.env: No such file or directory
open /Users/karol/sia/skynet-webportal/.env: no such file or directory
```

after
```
➜  skynet-webportal git:(master) ✗ ./dc down
open /Users/karol/sia/skynet-webportal/.env: no such file or directory
```