### PR TITLE
remove outdated readme info

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,6 @@ supports is located at https://portal-docs.skynetlabs.com/.
 Some scripts and setup documentation contained in this repository
 (`skynet-webportal`) may be outdated and generally should not be used.
 
-## Web application
-
-Change current directory with `cd packages/website`.
-
-Use `yarn start` to start the development server.
-
-Use `yarn build` to compile the application to `/public` directory.
-
-You can use the below build parameters to customize your web application.
-
-- development example `GATSBY_API_URL=https://siasky.dev yarn start`
-- production example `GATSBY_API_URL=https://siasky.net yarn build`
-
-List of available parameters:
-
-- `GATSBY_API_URL`: override api url (defaults to location origin)
-
 ## License
 
 Skynet uses a custom [License](./LICENSE.md). The Skynet License is a source code license that allows you to use, modify
@@ -33,19 +16,3 @@ and distribute the software, but you must preserve the payment mechanism in the 
 For the purposes of complying with our code license, you can use the following Siacoin address:
 
 `fb6c9320bc7e01fbb9cd8d8c3caaa371386928793c736837832e634aaaa484650a3177d6714a`
-
-## Running a Portal
-For those interested in running a Webportal, head over to our developer docs [here](https://portal-docs.skynetlabs.com/) to learn more.
-
-## Contributing
-
-### Testing Your Code
-
-Before pushing your code, you should verify that it will pass our online test suite.
-
-**Cypress Tests**
-Verify the Cypress test suite by doing the following:
-
-1. In one terminal screen run `GATSBY_API_URL=https://siasky.net website serve`
-1. In a second terminal screen run `yarn cypress run`
-


### PR DESCRIPTION
- removed "Web application" section since portal website has been moved to its separate repository
- removed "Running a Portal" section since this information is already on top of the readme in "Latest Setup Documentation" section
- removed "Contributing" section since it only contains "Testing Your Code" section that relates to portal website which has been moved to its separate repository