### PR TITLE
remove deploy configuration

### DIFF
--- a/docker-compose.malware-scanner.yml
+++ b/docker-compose.malware-scanner.yml
@@ -17,10 +17,6 @@ services:
       - ./docker/clamav/clamd.conf:/etc/clamav/clamd.conf:ro
     expose:
       - 3310 # NEVER expose this outside of the local network!
-    deploy:
-      resources:
-        limits:
-          cpus: "${CLAMAV_CPU:-0.50}"
     networks:
       shared:
         ipv4_address: 10.10.10.100


### PR DESCRIPTION
Deploy key is ignored when using docker compose.

> Some services (clamav) use the 'deploy' key, which will be ignored. Compose does not support 'deploy' configuration - use `docker stack deploy` to deploy to a swarm.