### PR TITLE
Amend skyd logrotate and add pinner

### DIFF
--- a/setup-scripts/logrotate.d/skynet-webportal-pinner
+++ b/setup-scripts/logrotate.d/skynet-webportal-pinner
@@ -1,0 +1,11 @@
+/home/user/skynet-webportal/docker/data/pinner/*.log {
+    daily
+    rotate 10
+    minsize 100M
+    copytruncate
+    notifempty
+    dateext
+    missingok
+    compress
+    compressoptions --best
+}

--- a/setup-scripts/logrotate.d/skynet-webportal-skyd
+++ b/setup-scripts/logrotate.d/skynet-webportal-skyd
@@ -1,13 +1,12 @@
 /home/user/skynet-webportal/docker/data/sia/*.log 
 /home/user/skynet-webportal/docker/data/sia/*/*.log {
     daily
-    rotate 3650
-    minsize 500M
-    create 644 root root
+    rotate 10
+    minsize 100M
+    copytruncate
     notifempty
     dateext
     missingok
     compress
     compressoptions --best
-    delaycompress
 }


### PR DESCRIPTION
- change skyd logrotate config to use "copytruncate"
  - "copytruncate" means that log file will be copied first and then original will be truncated
  - previous option "create" renames an original file and creates a new empty file instead but it was ineffective because skyd would keep file handle after renaming and still write to the rotated file until its restarted
  - no "delaycompress" since the new file can be compressed right away
- decreased the amount of log data we want to keep for skyd
- add new pinner logrotate config (uses "copytruncate" as well)