### PR TITLE
delete skylink dumps older than week

### DIFF
--- a/scripts/backup-aws-s3.sh
+++ b/scripts/backup-aws-s3.sh
@@ -50,6 +50,7 @@ aws s3 sync --no-progress /home/user/skynet-webportal/docker/data/nginx/logs s3:
 # generate and sync skylinks dump
 SKYLINKS_PATH=logs/skylinks/$(date +"%Y-%m-%d").log
 mkdir -p /home/user/skynet-webportal/logs/skylinks # ensure path exists
+find /home/user/skynet-webportal/logs/skylinks -type f -mtime +7 -delete # delete skylink dumps older than 7 days
 docker exec sia siac skynet ls --recursive --alert-suppress > /home/user/skynet-webportal/${SKYLINKS_PATH}
 aws s3 cp --no-progress /home/user/skynet-webportal/${SKYLINKS_PATH} s3://${BUCKET_NAME}/${SERVER_PREFIX}/${SKYLINKS_PATH}
 


### PR DESCRIPTION
skylinks in folder `/home/user/skynet-webportal/logs/skylinks` are versioned with date and on some servers we have months of logs that can take 100M+ each which on one server made up over 20G

this pull request adds a cleanup of log files older than a week to script that produces them (it runs in crontab daily)